### PR TITLE
Fix ddsHeader size assertion.

### DIFF
--- a/gli/core/load_dds.inl
+++ b/gli/core/load_dds.inl
@@ -141,7 +141,7 @@ namespace detail
 
 inline storage load_dds(char const * Data, std::size_t Size)
 {
-	assert(Data && (Size >= (sizeof(char[4]) + sizeof(detail::ddsHeader))));
+	assert(Data && (Size >= sizeof(detail::ddsHeader)));
 
 	detail::ddsHeader const & HeaderDesc(*reinterpret_cast<detail::ddsHeader const *>(Data));
 	size_t Offset = sizeof(detail::ddsHeader);


### PR DESCRIPTION
The magic number has already been accounted for in the header structure.