### PR TITLE
Extended flip() to more texture types and to S3TC compression

### DIFF
--- a/gli/core/flip.hpp
+++ b/gli/core/flip.hpp
@@ -28,8 +28,12 @@
 
 #pragma once
 
+#include <array>
+
 #include "../texture2d.hpp"
 #include "../texture2d_array.hpp"
+#include "../texture_cube.hpp"
+#include "../texture_cube_array.hpp"
 
 namespace gli
 {

--- a/gli/core/flip.inl
+++ b/gli/core/flip.inl
@@ -26,7 +26,8 @@
 /// @author Christophe Riccio
 ///////////////////////////////////////////////////////////////////////////////////
 
-namespace gli{
+namespace gli
+{
 namespace detail
 {
 	inline void flip(image ImageDst, image ImageSrc, std::size_t BlockSize)
@@ -45,27 +46,223 @@ namespace detail
 		}
 	}
 
+	inline void flip_block_s3tc(glm::byte* BlockDst, glm::byte* BlockSrc, format Format, bool HeightTwo)
+	{
+		// DXT1
+		if(Format == FORMAT_RGB_DXT1_UNORM || Format == FORMAT_RGB_DXT1_SRGB)
+		{
+			std::array<glm::byte, 8> BlockFlip;
+	
+			// 0, 1 color1
+			// 2, 3 color2
+			// 4, 5, 6, 7 color rows
+			if(HeightTwo)
+			{
+				BlockFlip[0] = BlockSrc[0];
+				BlockFlip[1] = BlockSrc[1];
+				BlockFlip[2] = BlockSrc[2];
+				BlockFlip[3] = BlockSrc[3];
+				BlockFlip[4] = BlockSrc[5];
+				BlockFlip[5] = BlockSrc[4];
+				BlockFlip[6] = BlockFlip[7] = 0;
+				
+				memcpy(BlockDst, BlockFlip.data(), 8);
+				return;
+			}
+
+			BlockFlip[0] = BlockSrc[0];
+			BlockFlip[1] = BlockSrc[1];
+			BlockFlip[2] = BlockSrc[2];
+			BlockFlip[3] = BlockSrc[3];
+			BlockFlip[4] = BlockSrc[7];
+			BlockFlip[5] = BlockSrc[6];
+			BlockFlip[6] = BlockSrc[5];
+			BlockFlip[7] = BlockSrc[4];
+			
+			memcpy(BlockDst, BlockFlip.data(), 8);
+			return;
+		}
+
+		// DXT1 w/ alpha
+		if(Format == FORMAT_RGBA_DXT1_UNORM || Format == FORMAT_RGBA_DXT1_SRGB)
+		{
+			// ?? can't find any spec for how a DXT1 texture with alpha is laid out
+			assert(false);
+		}
+
+		// DXT3
+		if(Format == FORMAT_RGBA_DXT3_UNORM || Format == FORMAT_RGBA_DXT3_SRGB)
+		{
+			std::array<glm::byte, 16> BlockFlip;
+
+			// 0 - 7 alpha pixels (two bytes per row)
+			// 8, 9 color1
+			// 10, 11 color2
+			// 12, 13, 14, 15 pixel rows
+			if(HeightTwo)
+			{
+				// flip alpha
+				BlockFlip[0] = BlockSrc[2];
+				BlockFlip[1] = BlockSrc[3];
+				BlockFlip[2] = BlockSrc[0];
+				BlockFlip[3] = BlockSrc[1];
+				BlockFlip[4] = BlockFlip[5] = BlockFlip[6] = BlockFlip[7] = 0;
+
+				// save color
+				BlockFlip[8] = BlockSrc[8];
+				BlockFlip[9] = BlockSrc[9];
+				BlockFlip[10] = BlockSrc[10];
+				BlockFlip[11] = BlockSrc[11];
+
+				// flip color
+				BlockFlip[12] = BlockSrc[13];
+				BlockFlip[13] = BlockSrc[12];
+				BlockFlip[14] = BlockFlip[15] = 0;
+			
+				memcpy(BlockDst, BlockFlip.data(), 16);
+				return;
+			}
+
+			// flip alpha
+			BlockFlip[0] = BlockSrc[6];
+			BlockFlip[1] = BlockSrc[7];
+			BlockFlip[2] = BlockSrc[4];
+			BlockFlip[3] = BlockSrc[5];
+			BlockFlip[4] = BlockSrc[2];
+			BlockFlip[5] = BlockSrc[3];
+			BlockFlip[6] = BlockSrc[0];
+			BlockFlip[7] = BlockSrc[1];
+
+			// save color
+			BlockFlip[8] = BlockSrc[8];
+			BlockFlip[9] = BlockSrc[9];
+			BlockFlip[10] = BlockSrc[10];
+			BlockFlip[11] = BlockSrc[11];
+
+			// flip color
+			BlockFlip[12] = BlockSrc[15];
+			BlockFlip[13] = BlockSrc[14];
+			BlockFlip[14] = BlockSrc[13];
+			BlockFlip[15] = BlockSrc[12];
+			
+			memcpy(BlockDst, BlockFlip.data(), 16);
+			return;
+		}
+
+		// DXT5
+		if(Format == FORMAT_RGBA_DXT5_UNORM || Format == FORMAT_RGBA_DXT5_SRGB)
+		{
+			std::array<glm::byte, 16> BlockFlip;
+
+			// 0 alpha1
+			// 1 alpha2
+			// 2, 3, 4, 5, 6, 7 alpha data (3 bits per pixel)
+			// 8, 9 color1
+			// 10, 11 color2
+			// 12, 13, 14, 15 pixel rows
+			if(HeightTwo)
+			{
+				// save alpha
+				BlockFlip[0] = BlockSrc[0];
+				BlockFlip[1] = BlockSrc[1];
+
+				// flip alpha
+				BlockFlip[2] = (BlockSrc[3] & 0b11110000) >> 4 + (BlockSrc[4] & 0b1111) << 4;
+				BlockFlip[3] = (BlockSrc[4] & 0b11110000) >> 4 + (BlockSrc[2] & 0b1111) << 4;
+				BlockFlip[4] = (BlockSrc[2] & 0b11110000) >> 4 + (BlockSrc[3] & 0b1111) << 4;
+				BlockFlip[5] = BlockFlip[6] = BlockFlip[7] = 0;
+
+				// save color
+				BlockFlip[8] = BlockSrc[8];
+				BlockFlip[9] = BlockSrc[9];
+				BlockFlip[10] = BlockSrc[10];
+				BlockFlip[11] = BlockSrc[11];
+
+				// flip color
+				BlockFlip[12] = BlockSrc[13];
+				BlockFlip[13] = BlockSrc[12];
+				BlockFlip[14] = BlockFlip[15] = 0;
+			
+				memcpy(BlockDst, BlockFlip.data(), 16);
+				return;
+			}
+
+			// save alpha
+			BlockFlip[0] = BlockSrc[0];
+			BlockFlip[1] = BlockSrc[1];
+
+			// flip alpha
+			BlockFlip[2] = (BlockSrc[6] & 0b11110000) >> 4 + (BlockSrc[7] & 0b1111) << 4;
+			BlockFlip[3] = (BlockSrc[7] & 0b11110000) >> 4 + (BlockSrc[5] & 0b1111) << 4;
+			BlockFlip[4] = (BlockSrc[5] & 0b11110000) >> 4 + (BlockSrc[6] & 0b1111) << 4;
+			BlockFlip[5] = (BlockSrc[3] & 0b11110000) >> 4 + (BlockSrc[4] & 0b1111) << 4;
+			BlockFlip[6] = (BlockSrc[4] & 0b11110000) >> 4 + (BlockSrc[2] & 0b1111) << 4;
+			BlockFlip[7] = (BlockSrc[2] & 0b11110000) >> 4 + (BlockSrc[3] & 0b1111) << 4;
+
+			// save color
+			BlockFlip[8] = BlockSrc[8];
+			BlockFlip[9] = BlockSrc[9];
+			BlockFlip[10] = BlockSrc[10];
+			BlockFlip[11] = BlockSrc[11];
+
+			// flip color
+			BlockFlip[12] = BlockSrc[15];
+			BlockFlip[13] = BlockSrc[14];
+			BlockFlip[14] = BlockSrc[13];
+			BlockFlip[15] = BlockSrc[12];
+
+			memcpy(BlockDst, BlockFlip.data(), 16);
+			return;
+		}
+		
+		// invalid format specified (unknown S3TC format?)
+		assert(false);
+	}
+
+	inline void flip_s3tc(image ImageDst, image ImageSrc, format Format)
+	{
+		if(ImageSrc.dimensions().y == 1)
+		{
+			memcpy(ImageDst.data(),
+				   ImageSrc.data(),
+				   ImageSrc.size());
+			return;
+		}
+
+		std::size_t const XBlocks = ImageSrc.dimensions().x <= 4 ? 1 : ImageSrc.dimensions().x / 4;
+
+		if(ImageSrc.dimensions().y == 2)
+		{
+			for(std::size_t i_block = 0; i_block < XBlocks; ++i_block)
+				flip_block_s3tc(ImageDst.data<glm::byte>() + i_block * block_size(Format), ImageSrc.data<glm::byte>() + i_block * block_size(Format), Format, true);
+			
+			return;
+		}
+
+		std::size_t const MaxYBlock = ImageSrc.dimensions().y / 4 - 1;
+		for(std::size_t i_row = 0; i_row <= MaxYBlock; ++i_row)
+			for(std::size_t i_block = 0; i_block < XBlocks; ++i_block)
+				flip_block_s3tc(ImageDst.data<glm::byte>() + (MaxYBlock - i_row) * block_size(Format) * XBlocks + i_block * block_size(Format), ImageSrc.data<glm::byte>() + i_row * block_size(Format) * XBlocks + i_block * block_size(Format), Format, false);
+	}
 }//namespace detail
-
-/*
-template <>
-inline image flip(image const & Image)
-{
-
-}
-*/
 
 template <>
 inline texture2D flip(texture2D const & Texture)
 {
-	assert(!gli::is_compressed(Texture.format()));
+	assert(!is_compressed(Texture.format()) || is_compressed_s3tc(Texture.format()));
 
 	texture2D Flip(Texture.format(), Texture.dimensions(), Texture.levels());
 
-	gli::size_t const BlockSize = block_size(Texture.format());
+	if(!is_compressed(Texture.format()))
+	{
+		gli::size_t const BlockSize = block_size(Texture.format());
 
-	for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
-		detail::flip(Flip[Level], Texture[Level], BlockSize);
+		for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
+			detail::flip(Flip[Level], Texture[Level], BlockSize);
+	}
+	else
+		for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
+			detail::flip_s3tc(Flip[Level], Texture[Level], Texture.format());
 
 	return Flip;
 }
@@ -73,17 +270,95 @@ inline texture2D flip(texture2D const & Texture)
 template <>
 inline texture2DArray flip(texture2DArray const & Texture)
 {
-	assert(!gli::is_compressed(Texture.format()));
+	assert(!is_compressed(Texture.format()) || is_compressed_s3tc(Texture.format()));
 
 	texture2DArray Flip(Texture.format(), Texture.dimensions(), Texture.layers(), Texture.levels());
 
-	gli::size_t const BlockSize = block_size(Texture.format());
+	if(!is_compressed(Texture.format()))
+	{
+		gli::size_t const BlockSize = block_size(Texture.format());
 
-	for(std::size_t Layer = 0; Layer < Flip.layers(); ++Layer)
-	for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
-		detail::flip(Flip[Layer][Level], Texture[Layer][Level], BlockSize);
+		for(std::size_t Layer = 0; Layer < Flip.layers(); ++Layer)
+		for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
+			detail::flip(Flip[Layer][Level], Texture[Layer][Level], BlockSize);
+	}
+	else
+		for(std::size_t Layer = 0; Layer < Flip.layers(); ++Layer)
+		for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
+			detail::flip_s3tc(Flip[Layer][Level], Texture[Layer][Level], Texture.format());
 
 	return Flip;
+}
+
+template <>
+inline textureCube flip(textureCube const & Texture)
+{
+	assert(!is_compressed(Texture.format()) || is_compressed_s3tc(Texture.format()));
+
+	textureCube Flip(Texture.format(), Texture.dimensions(), Texture.levels());
+
+	if(!is_compressed(Texture.format()))
+	{
+		gli::size_t const BlockSize = block_size(Texture.format());
+
+		for(std::size_t Face = 0; Face < Flip.faces(); ++Face)
+		for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
+			detail::flip(Flip[Face][Level], Texture[Face][Level], BlockSize);
+	}
+	else
+		for(std::size_t Face = 0; Face < Flip.faces(); ++Face)
+		for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
+			detail::flip_s3tc(Flip[Face][Level], Texture[Face][Level], Texture.format());
+
+	return Flip;
+}
+
+template <>
+inline textureCubeArray flip(textureCubeArray const & Texture)
+{
+	assert(!is_compressed(Texture.format()) || is_compressed_s3tc(Texture.format()));
+
+	textureCubeArray Flip(Texture.format(), Texture.dimensions(), Texture.layers(), Texture.levels());
+
+	if(!is_compressed(Texture.format()))
+	{
+		gli::size_t const BlockSize = block_size(Texture.format());
+
+		for(std::size_t Layer = 0; Layer < Flip.layers(); ++Layer)
+		for(std::size_t Face = 0; Face < Flip.faces(); ++Face)
+		for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
+			detail::flip(Flip[Layer][Face][Level], Texture[Layer][Face][Level], BlockSize);
+	}
+	else
+		for(std::size_t Layer = 0; Layer < Flip.layers(); ++Layer)
+		for(std::size_t Face = 0; Face < Flip.faces(); ++Face)
+		for(std::size_t Level = 0; Level < Flip.levels(); ++Level)
+			detail::flip_s3tc(Flip[Layer][Face][Level], Texture[Layer][Face][Level], Texture.format());
+
+	return Flip;
+}
+
+template <>
+inline texture flip(texture const & Texture)
+{
+	switch(Texture.target())
+	{
+	case TARGET_2D:
+		return flip(texture2D(Texture));
+
+	case TARGET_2D_ARRAY:
+		return flip(texture2DArray(Texture));
+
+	case TARGET_CUBE:
+		return flip(textureCube(Texture));
+
+	case TARGET_CUBE_ARRAY:
+		return flip(textureCubeArray(Texture));
+
+	default:
+		assert(false);
+		return Texture;
+	}
 }
 
 }//namespace gli

--- a/gli/core/flip.inl
+++ b/gli/core/flip.inl
@@ -90,8 +90,11 @@ namespace detail
 	
 	inline void flip_block_s3tc(uint8_t* BlockDst, uint8_t* BlockSrc, format Format, bool HeightTwo)
 	{
-		// DXT1
-		if(Format == FORMAT_RGB_DXT1_UNORM || Format == FORMAT_RGB_DXT1_SRGB)
+		// All DXT-compressed textures are stored as RGBA, the RGB format is used only to tell OpenGL
+		// how to interpret the data. It does not, however, matter for how the data is laid out,
+		// so it can be flipped the same way.
+		if(Format == FORMAT_RGB_DXT1_UNORM || Format == FORMAT_RGB_DXT1_SRGB
+		|| Format == FORMAT_RGBA_DXT1_UNORM || Format == FORMAT_RGBA_DXT1_SRGB)
 		{
 			dxt1_block* Src = reinterpret_cast<dxt1_block*>(BlockSrc);
 			dxt1_block* Dst = reinterpret_cast<dxt1_block*>(BlockDst);
@@ -116,13 +119,6 @@ namespace detail
 			Dst->Row3 = Src->Row0;
 				
 			return;
-		}
-
-		// DXT1 w/ alpha
-		if(Format == FORMAT_RGBA_DXT1_UNORM || Format == FORMAT_RGBA_DXT1_SRGB)
-		{
-			// ?? can't find any spec for how a DXT1 texture with alpha is laid out
-			assert(false);
 		}
 
 		// DXT3

--- a/gli/core/flip.inl
+++ b/gli/core/flip.inl
@@ -90,9 +90,12 @@ namespace detail
 	
 	inline void flip_block_s3tc(uint8_t* BlockDst, uint8_t* BlockSrc, format Format, bool HeightTwo)
 	{
-		// All DXT-compressed textures are stored as RGBA, the RGB format is used only to tell OpenGL
-		// how to interpret the data. It does not, however, matter for how the data is laid out,
-		// so it can be flipped the same way.
+		// There is no distinction between RGB and RGBA in DXT-compressed textures,
+		// it is used only to tell OpenGL how to interpret the data.
+		// Moreover, in DXT1 (which does not contain an alpha channel), transparency can be emulated
+		// using Color0 and Color1 on a per-compression-block basis.
+		// There is no difference in how textures with and without transparency are laid out in the file,
+		// so they can be flipped using the same method.
 		if(Format == FORMAT_RGB_DXT1_UNORM || Format == FORMAT_RGB_DXT1_SRGB
 		|| Format == FORMAT_RGBA_DXT1_UNORM || Format == FORMAT_RGBA_DXT1_SRGB)
 		{

--- a/gli/core/format.inl
+++ b/gli/core/format.inl
@@ -308,6 +308,11 @@ namespace detail
 	{
 		return detail::get_format_info(Format).Flags & detail::CAP_COMPRESSED_BIT;
 	}
+	
+	inline bool is_compressed_s3tc(format Format)
+	{
+		return Format >= FORMAT_RGB_DXT1_UNORM && Format <= FORMAT_RGBA_DXT5_SRGB;
+	}
 
 	inline std::uint32_t block_size(format Format)
 	{

--- a/test/core/core_flip.cpp
+++ b/test/core/core_flip.cpp
@@ -120,6 +120,10 @@ int main()
 		dxt1_block{63712u, 255u, 228u, 144u, 64u, 0u}, dxt1_block{2516u, 215u, 152u, 173u, 215u, 106u});
 		
 	Error += test_texture(
+		gli::texture2D(gli::FORMAT_RGBA_DXT1_UNORM, TextureSize, Levels),
+		dxt1_block{63712u, 255u, 228u, 144u, 64u, 0u}, dxt1_block{255u, 63712u, 255u, 255u, 255u, 255u});
+
+	Error += test_texture(
 		gli::texture2D(gli::FORMAT_RGBA_DXT3_UNORM, TextureSize, Levels),
 		dxt3_block{12514u, 1512u, 12624u, 16614u, 63712u, 255u, 228u, 144u, 64u, 0u}, dxt3_block{36125u, 2416u, 46314u, 10515u, 2516u, 215u, 152u, 173u, 215u, 106u});
 		

--- a/test/core/core_flip.cpp
+++ b/test/core/core_flip.cpp
@@ -27,6 +27,7 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 #include <gli/gli.hpp>
+#include <iostream>
 
 template <typename texture, typename genType>
 int test_texture
@@ -47,12 +48,52 @@ int test_texture
 
 	texture TextureC = gli::flip(TextureB);
 	Error += TextureC == TextureA ? 0 : 1;
-
+	
 	return Error;
 }
 
+struct dxt1_block {
+	uint16_t Color0;
+	uint16_t Color1;
+	uint8_t Row0;
+	uint8_t Row1;
+	uint8_t Row2;
+	uint8_t Row3;
+};
+
+struct dxt3_block {
+	uint16_t AlphaRow0;
+	uint16_t AlphaRow1;
+	uint16_t AlphaRow2;
+	uint16_t AlphaRow4;
+	uint16_t Color0;
+	uint16_t Color1;
+	uint8_t Row0;
+	uint8_t Row1;
+	uint8_t Row2;
+	uint8_t Row3;
+};
+
+struct dxt5_block {
+	uint8_t Alpha0;
+	uint8_t Alpha1;
+	uint16_t AlphaRows0;
+	uint16_t AlphaRows1;
+	uint16_t AlphaRows3;
+	uint16_t Color0;
+	uint16_t Color1;
+	uint8_t Row0;
+	uint8_t Row1;
+	uint8_t Row2;
+	uint8_t Row3;
+};
+
 int main()
 {
+	static_assert(sizeof(dxt1_block) == 8, "");
+	static_assert(sizeof(dxt3_block) == 16, "");
+	static_assert(sizeof(dxt5_block) == 16, "");
+	
 	int Error(0);
 
 	gli::texture2D::dim_type const TextureSize(32);
@@ -75,11 +116,39 @@ int main()
 		glm::f32vec4(1.0, 0.5, 0.0, 1.0), glm::f32vec4(0.0, 0.5, 1.0, 1.0));
 
 	Error += test_texture(
+		gli::texture2D(gli::FORMAT_RGB_DXT1_UNORM, TextureSize, Levels),
+		dxt1_block{63712u, 255u, 228u, 144u, 64u, 0u}, dxt1_block{2516u, 215u, 152u, 173u, 215u, 106u});
+		
+	Error += test_texture(
+		gli::texture2D(gli::FORMAT_RGBA_DXT3_UNORM, TextureSize, Levels),
+		dxt3_block{12514u, 1512u, 12624u, 16614u, 63712u, 255u, 228u, 144u, 64u, 0u}, dxt3_block{36125u, 2416u, 46314u, 10515u, 2516u, 215u, 152u, 173u, 215u, 106u});
+		
+	Error += test_texture(
+		gli::texture2D(gli::FORMAT_RGBA_DXT5_UNORM, TextureSize, Levels),
+		dxt5_block{255u, 0u, 16414u, 12845u, 62020u, 63712u, 255u, 228u, 144u, 64u, 0u}, dxt5_block{0u, 255u, 16016u, 58582u, 15304u, 2516u, 215u, 152u, 173u, 215u, 106u});
+		
+	Error += test_texture(
 		gli::texture2DArray(gli::FORMAT_RGBA8_UNORM, TextureSize, 4, Levels),
 		glm::u8vec4(255, 128, 0, 255), glm::u8vec4(0, 128, 255, 255));
 
 	Error += test_texture(
 		gli::texture2DArray(gli::FORMAT_RGBA32_SFLOAT, TextureSize, 4, Levels),
+		glm::f32vec4(1.0, 0.5, 0.0, 1.0), glm::f32vec4(0.0, 0.5, 1.0, 1.0));
+		
+	Error += test_texture(
+		gli::textureCube(gli::FORMAT_RGBA8_UNORM, TextureSize, Levels),
+		glm::u8vec4(255, 128, 0, 255), glm::u8vec4(0, 128, 255, 255));
+
+	Error += test_texture(
+		gli::textureCube(gli::FORMAT_RGBA32_SFLOAT, TextureSize, Levels),
+		glm::f32vec4(1.0, 0.5, 0.0, 1.0), glm::f32vec4(0.0, 0.5, 1.0, 1.0));
+		
+	Error += test_texture(
+		gli::textureCubeArray(gli::FORMAT_RGBA8_UNORM, TextureSize, 4, Levels),
+		glm::u8vec4(255, 128, 0, 255), glm::u8vec4(0, 128, 255, 255));
+
+	Error += test_texture(
+		gli::textureCubeArray(gli::FORMAT_RGBA32_SFLOAT, TextureSize, 4, Levels),
 		glm::f32vec4(1.0, 0.5, 0.0, 1.0), glm::f32vec4(0.0, 0.5, 1.0, 1.0));
 
 	return Error;


### PR DESCRIPTION
- Added flip() for texture2DArray, textureCube, textureCubeArray
- Added flip_s3tc() and flip_s3tc_block() for S3TC compressed images
- DXT1 compression with an alpha channel is NOT supported and causes an assertion failure. i'm happy to add it, but can't find any docs on how it is supposed to be laid out in memory