### PR TITLE
Improvements to CMake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,52 @@
-build/
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
 
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+gli/gli
+
+# CMake
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
+install_manifest.txt
+*.cmake
+# ^ May need to add future .cmake files as exceptions
+
+# Test logs
+Testing/*
+
+# Project Files
+Makefile
+*.cbp
+*.user
+
+# Misc.
+*.log
+build/
 *~
 *.swp
 *.swo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(MSVC)
 endif()
 
 if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") OR (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel") AND UNIX))
-	set(CMAKE_CXX_FLAGS "-std=c++0x")
+	set(CMAKE_CXX_FLAGS "-std=c++11")
 	add_definitions(-Wall)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 cmake_policy(VERSION 2.6)
 
 project(gli)
+set(GLI_VERSION "0.8.0.0")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
 enable_testing()
 
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 add_definitions(-DSOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories(".")
 
+option(GLI_TEST_ENABLE "GLI test" OFF)
+if(NOT GLI_TEST_ENABLE)
+    message(STATUS "GLI is a header only library, no need to build it. Set the option GLI_TEST_ENABLE with ON to build and run the test bench")
+endif()
+
 if(MSVC)
 	add_definitions(/Za)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,37 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external/${GLM_DIRECTORY})
 add_subdirectory(gli)
 add_subdirectory(test)
 #add_subdirectory(doc)
+
+set(GLI_INSTALL_CONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/gli")
+install(DIRECTORY gli DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/gliVersion.cmake"
+    VERSION ${GLI_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+# build tree package config
+configure_file(
+    cmake/gliBuildConfig.cmake.in
+    gliConfig.cmake
+    @ONLY
+)
+
+# install tree package config
+configure_package_config_file(
+    cmake/gliConfig.cmake.in
+    ${GLI_INSTALL_CONFIGDIR}/gliConfig.cmake
+    INSTALL_DESTINATION ${GLI_INSTALL_CONFIGDIR}
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/${GLI_INSTALL_CONFIGDIR}/gliConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/gliVersion.cmake"
+    DESTINATION ${GLI_INSTALL_CONFIGDIR}
+)
+
+export(PACKAGE gli)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,13 @@
+## This file should be placed in the root directory of your project.
+## Then modify the CMakeLists.txt file in the root directory of your
+## project to incorporate the testing dashboard.
+## # The following are required to uses Dart and the Cdash dashboard
+##   ENABLE_TESTING()
+##   INCLUDE(CTest)
+set(CTEST_PROJECT_NAME "GLI")
+set(CTEST_NIGHTLY_START_TIME "00:00:00 EST")
+
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=GLI")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/cmake/CMakePackageConfigHelpers.cmake
+++ b/cmake/CMakePackageConfigHelpers.cmake
@@ -1,0 +1,227 @@
+# - CONFIGURE_PACKAGE_CONFIG_FILE(), WRITE_BASIC_PACKAGE_VERSION_FILE()
+#
+#    CONFIGURE_PACKAGE_CONFIG_FILE(<input> <output> INSTALL_DESTINATION <path>
+#                                                   [PATH_VARS <var1> <var2> ... <varN>]
+#                                                   [NO_SET_AND_CHECK_MACRO]
+#                                                   [NO_CHECK_REQUIRED_COMPONENTS_MACRO])
+#
+# CONFIGURE_PACKAGE_CONFIG_FILE() should be used instead of the plain
+# CONFIGURE_FILE() command when creating the <Name>Config.cmake or <Name>-config.cmake
+# file for installing a project or library. It helps making the resulting package
+# relocatable by avoiding hardcoded paths in the installed Config.cmake file.
+#
+# In a FooConfig.cmake file there may be code like this to make the
+# install destinations know to the using project:
+#   set(FOO_INCLUDE_DIR   "@CMAKE_INSTALL_FULL_INCLUDEDIR@" )
+#   set(FOO_DATA_DIR   "@CMAKE_INSTALL_PREFIX@/@RELATIVE_DATA_INSTALL_DIR@" )
+#   set(FOO_ICONS_DIR   "@CMAKE_INSTALL_PREFIX@/share/icons" )
+#   ...logic to determine installedPrefix from the own location...
+#   set(FOO_CONFIG_DIR  "${installedPrefix}/@CONFIG_INSTALL_DIR@" )
+# All 4 options shown above are not sufficient, since the first 3 hardcode
+# the absolute directory locations, and the 4th case works only if the logic
+# to determine the installedPrefix is correct, and if CONFIG_INSTALL_DIR contains
+# a relative path, which in general cannot be guaranteed.
+# This has the effect that the resulting FooConfig.cmake file would work poorly
+# under Windows and OSX, where users are used to choose the install location
+# of a binary package at install time, independent from how CMAKE_INSTALL_PREFIX
+# was set at build/cmake time.
+#
+# Using CONFIGURE_PACKAGE_CONFIG_FILE() helps. If used correctly, it makes the
+# resulting FooConfig.cmake file relocatable.
+# Usage:
+#   1. write a FooConfig.cmake.in file as you are used to
+#   2. insert a line containing only the string "@PACKAGE_INIT@"
+#   3. instead of SET(FOO_DIR "@SOME_INSTALL_DIR@"), use SET(FOO_DIR "@PACKAGE_SOME_INSTALL_DIR@")
+#      (this must be after the @PACKAGE_INIT@ line)
+#   4. instead of using the normal CONFIGURE_FILE(), use CONFIGURE_PACKAGE_CONFIG_FILE()
+#
+# The <input> and <output> arguments are the input and output file, the same way
+# as in CONFIGURE_FILE().
+#
+# The <path> given to INSTALL_DESTINATION must be the destination where the FooConfig.cmake
+# file will be installed to. This can either be a relative or absolute path, both work.
+#
+# The variables <var1> to <varN> given as PATH_VARS are the variables which contain
+# install destinations. For each of them the macro will create a helper variable
+# PACKAGE_<var...>. These helper variables must be used
+# in the FooConfig.cmake.in file for setting the installed location. They are calculated
+# by CONFIGURE_PACKAGE_CONFIG_FILE() so that they are always relative to the
+# installed location of the package. This works both for relative and also for absolute locations.
+# For absolute locations it works only if the absolute location is a subdirectory
+# of CMAKE_INSTALL_PREFIX.
+#
+# By default configure_package_config_file() also generates two helper macros,
+# set_and_check() and check_required_components() into the FooConfig.cmake file.
+#
+# set_and_check() should be used instead of the normal set()
+# command for setting directories and file locations. Additionally to setting the
+# variable it also checks that the referenced file or directory actually exists
+# and fails with a FATAL_ERROR otherwise. This makes sure that the created
+# FooConfig.cmake file does not contain wrong references.
+# When using the NO_SET_AND_CHECK_MACRO, this macro is not generated into the
+# FooConfig.cmake file.
+#
+# check_required_components(<package_name>) should be called at the end of the
+# FooConfig.cmake file if the package supports components.
+# This macro checks whether all requested, non-optional components have been found,
+# and if this is not the case, sets the Foo_FOUND variable to FALSE, so that the package
+# is considered to be not found.
+# It does that by testing the Foo_<Component>_FOUND variables for all requested
+# required components.
+# When using the NO_CHECK_REQUIRED_COMPONENTS option, this macro is not generated
+# into the FooConfig.cmake file.
+#
+# For an example see below the documentation for WRITE_BASIC_PACKAGE_VERSION_FILE().
+#
+#
+#  WRITE_BASIC_PACKAGE_VERSION_FILE( filename VERSION major.minor.patch COMPATIBILITY (AnyNewerVersion|SameMajorVersion|ExactVersion) )
+#
+# Writes a file for use as <package>ConfigVersion.cmake file to <filename>.
+# See the documentation of FIND_PACKAGE() for details on this.
+#    filename is the output filename, it should be in the build tree.
+#    major.minor.patch is the version number of the project to be installed
+# The COMPATIBILITY mode AnyNewerVersion means that the installed package version
+# will be considered compatible if it is newer or exactly the same as the requested version.
+# This mode should be used for packages which are fully backward compatible,
+# also across major versions.
+# If SameMajorVersion is used instead, then the behaviour differs from AnyNewerVersion
+# in that the major version number must be the same as requested, e.g. version 2.0 will
+# not be considered compatible if 1.0 is requested.
+# This mode should be used for packages which guarantee backward compatibility within the
+# same major version.
+# If ExactVersion is used, then the package is only considered compatible if the requested
+# version matches exactly its own version number (not considering the tweak version).
+# For example, version 1.2.3 of a package is only considered compatible to requested version 1.2.3.
+# This mode is for packages without compatibility guarantees.
+# If your project has more elaborated version matching rules, you will need to write your
+# own custom ConfigVersion.cmake file instead of using this macro.
+#
+# Internally, this macro executes configure_file() to create the resulting
+# version file. Depending on the COMPATIBLITY, either the file
+# BasicConfigVersion-SameMajorVersion.cmake.in or BasicConfigVersion-AnyNewerVersion.cmake.in
+# is used. Please note that these two files are internal to CMake and you should
+# not call configure_file() on them yourself, but they can be used as starting
+# point to create more sophisticted custom ConfigVersion.cmake files.
+#
+#
+# Example using both configure_package_config_file() and write_basic_package_version_file():
+# CMakeLists.txt:
+#   set(INCLUDE_INSTALL_DIR include/ ... CACHE )
+#   set(LIB_INSTALL_DIR lib/ ... CACHE )
+#   set(SYSCONFIG_INSTALL_DIR etc/foo/ ... CACHE )
+#   ...
+#   include(CMakePackageConfigHelpers)
+#   configure_package_config_file(FooConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/FooConfig.cmake
+#                                 INSTALL_DESTINATION ${LIB_INSTALL_DIR}/Foo/cmake
+#                                 PATH_VARS INCLUDE_INSTALL_DIR SYSCONFIG_INSTALL_DIR)
+#   write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/FooConfigVersion.cmake
+#                                    VERSION 1.2.3
+#                                    COMPATIBILITY SameMajorVersion )
+#   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/FooConfig.cmake ${CMAKE_CURRENT_BINARY_DIR}/FooConfigVersion.cmake
+#           DESTINATION ${LIB_INSTALL_DIR}/Foo/cmake )
+#
+# With a FooConfig.cmake.in:
+#   set(FOO_VERSION x.y.z)
+#   ...
+#   @PACKAGE_INIT@
+#   ...
+#   set_and_check(FOO_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+#   set_and_check(FOO_SYSCONFIG_DIR "@PACKAGE_SYSCONFIG_INSTALL_DIR@")
+#
+#   check_required_components(Foo)
+
+
+#=============================================================================
+# Copyright 2012 Alexander Neundorf <neundorf@kde.org>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+include(CMakeParseArguments)
+
+include(WriteBasicConfigVersionFile)
+
+macro(WRITE_BASIC_PACKAGE_VERSION_FILE)
+  write_basic_config_version_file(${ARGN})
+endmacro()
+
+
+function(CONFIGURE_PACKAGE_CONFIG_FILE _inputFile _outputFile)
+  set(options NO_SET_AND_CHECK_MACRO NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+  set(oneValueArgs INSTALL_DESTINATION )
+  set(multiValueArgs PATH_VARS )
+
+  cmake_parse_arguments(CCF "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${ARGN})
+
+  if(CCF_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Unknown keywords given to CONFIGURE_PACKAGE_CONFIG_FILE(): \"${CCF_UNPARSED_ARGUMENTS}\"")
+  endif()
+
+  if(NOT CCF_INSTALL_DESTINATION)
+    message(FATAL_ERROR "No INSTALL_DESTINATION given to CONFIGURE_PACKAGE_CONFIG_FILE()")
+  endif()
+
+  if(IS_ABSOLUTE "${CCF_INSTALL_DESTINATION}")
+    set(absInstallDir "${CCF_INSTALL_DESTINATION}")
+  else()
+    set(absInstallDir "${CMAKE_INSTALL_PREFIX}/${CCF_INSTALL_DESTINATION}")
+  endif()
+  file(RELATIVE_PATH PACKAGE_RELATIVE_PATH "${absInstallDir}" "${CMAKE_INSTALL_PREFIX}" )
+
+  foreach(var ${CCF_PATH_VARS})
+    if(NOT DEFINED ${var})
+      message(FATAL_ERROR "Variable ${var} does not exist")
+    else()
+      if(IS_ABSOLUTE "${${var}}")
+        string(REPLACE "${CMAKE_INSTALL_PREFIX}" "\${PACKAGE_PREFIX_DIR}"
+                        PACKAGE_${var} "${${var}}")
+      else()
+        set(PACKAGE_${var} "\${PACKAGE_PREFIX_DIR}/${${var}}")
+      endif()
+    endif()
+  endforeach()
+
+  set(PACKAGE_INIT "
+####### Expanded from @PACKAGE_INIT@ by configure_package_config_file() #######
+get_filename_component(PACKAGE_PREFIX_DIR \"\${CMAKE_CURRENT_LIST_DIR}/${PACKAGE_RELATIVE_PATH}\" ABSOLUTE)
+")
+
+  if(NOT CCF_NO_SET_AND_CHECK_MACRO)
+    set(PACKAGE_INIT "${PACKAGE_INIT}
+macro(set_and_check _var _file)
+  set(\${_var} \"\${_file}\")
+  if(NOT EXISTS \"\${_file}\")
+    message(FATAL_ERROR \"File or directory \${_file} referenced by variable \${_var} does not exist !\")
+  endif()
+endmacro()
+")
+  endif()
+
+
+  if(NOT CCF_NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+    set(PACKAGE_INIT "${PACKAGE_INIT}
+macro(check_required_components _NAME)
+  foreach(comp \${\${_NAME}_FIND_COMPONENTS})
+    if(NOT \${_NAME}_\${comp}_FOUND)
+      if(\${_NAME}_FIND_REQUIRED_\${comp})
+        set(\${_NAME}_FOUND FALSE)
+      endif()
+    endif()
+  endforeach(comp)
+endmacro()
+")
+  endif()
+
+  set(PACKAGE_INIT "${PACKAGE_INIT}
+####################################################################################")
+
+  configure_file("${_inputFile}" "${_outputFile}" @ONLY)
+
+endfunction()

--- a/cmake/GNUInstallDirs.cmake
+++ b/cmake/GNUInstallDirs.cmake
@@ -1,0 +1,188 @@
+# - Define GNU standard installation directories
+# Provides install directory variables as defined for GNU software:
+#  http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+# Inclusion of this module defines the following variables:
+#  CMAKE_INSTALL_<dir>      - destination for files of a given type
+#  CMAKE_INSTALL_FULL_<dir> - corresponding absolute path
+# where <dir> is one of:
+#  BINDIR           - user executables (bin)
+#  SBINDIR          - system admin executables (sbin)
+#  LIBEXECDIR       - program executables (libexec)
+#  SYSCONFDIR       - read-only single-machine data (etc)
+#  SHAREDSTATEDIR   - modifiable architecture-independent data (com)
+#  LOCALSTATEDIR    - modifiable single-machine data (var)
+#  LIBDIR           - object code libraries (lib or lib64 or lib/<multiarch-tuple> on Debian)
+#  INCLUDEDIR       - C header files (include)
+#  OLDINCLUDEDIR    - C header files for non-gcc (/usr/include)
+#  DATAROOTDIR      - read-only architecture-independent data root (share)
+#  DATADIR          - read-only architecture-independent data (DATAROOTDIR)
+#  INFODIR          - info documentation (DATAROOTDIR/info)
+#  LOCALEDIR        - locale-dependent data (DATAROOTDIR/locale)
+#  MANDIR           - man documentation (DATAROOTDIR/man)
+#  DOCDIR           - documentation root (DATAROOTDIR/doc/PROJECT_NAME)
+# Each CMAKE_INSTALL_<dir> value may be passed to the DESTINATION options of
+# install() commands for the corresponding file type.  If the includer does
+# not define a value the above-shown default will be used and the value will
+# appear in the cache for editing by the user.
+# Each CMAKE_INSTALL_FULL_<dir> value contains an absolute path constructed
+# from the corresponding destination by prepending (if necessary) the value
+# of CMAKE_INSTALL_PREFIX.
+
+#=============================================================================
+# Copyright 2011 Nikita Krupen'ko <krnekit@gmail.com>
+# Copyright 2011 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+# Installation directories
+#
+if(NOT DEFINED CMAKE_INSTALL_BINDIR)
+  set(CMAKE_INSTALL_BINDIR "bin" CACHE PATH "user executables (bin)")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_SBINDIR)
+  set(CMAKE_INSTALL_SBINDIR "sbin" CACHE PATH "system admin executables (sbin)")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_LIBEXECDIR)
+  set(CMAKE_INSTALL_LIBEXECDIR "libexec" CACHE PATH "program executables (libexec)")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_SYSCONFDIR)
+  set(CMAKE_INSTALL_SYSCONFDIR "etc" CACHE PATH "read-only single-machine data (etc)")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_SHAREDSTATEDIR)
+  set(CMAKE_INSTALL_SHAREDSTATEDIR "com" CACHE PATH "modifiable architecture-independent data (com)")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_LOCALSTATEDIR)
+  set(CMAKE_INSTALL_LOCALSTATEDIR "var" CACHE PATH "modifiable single-machine data (var)")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  set(_LIBDIR_DEFAULT "lib")
+  # Override this default 'lib' with 'lib64' iff:
+  #  - we are on Linux system but NOT cross-compiling
+  #  - we are NOT on debian
+  #  - we are on a 64 bits system
+  # reason is: amd64 ABI: http://www.x86-64.org/documentation/abi.pdf
+  # For Debian with multiarch, use 'lib/${CMAKE_LIBRARY_ARCHITECTURE}' if
+  # CMAKE_LIBRARY_ARCHITECTURE is set (which contains e.g. "i386-linux-gnu"
+  # See http://wiki.debian.org/Multiarch
+  if((CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
+      AND NOT CMAKE_CROSSCOMPILING)
+    if (EXISTS "/etc/debian_version") # is this a debian system ?
+       if(CMAKE_LIBRARY_ARCHITECTURE)
+         set(_LIBDIR_DEFAULT "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+       endif()
+    else() # not debian, rely on CMAKE_SIZEOF_VOID_P:
+      if(NOT DEFINED CMAKE_SIZEOF_VOID_P)
+        message(AUTHOR_WARNING
+          "Unable to determine default CMAKE_INSTALL_LIBDIR directory because no target architecture is known. "
+          "Please enable at least one language before including GNUInstallDirs.")
+      else()
+        if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+          set(_LIBDIR_DEFAULT "lib64")
+        endif()
+      endif()
+    endif()
+  endif()
+  set(CMAKE_INSTALL_LIBDIR "${_LIBDIR_DEFAULT}" CACHE PATH "object code libraries (${_LIBDIR_DEFAULT})")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
+  set(CMAKE_INSTALL_INCLUDEDIR "include" CACHE PATH "C header files (include)")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_OLDINCLUDEDIR)
+  set(CMAKE_INSTALL_OLDINCLUDEDIR "/usr/include" CACHE PATH "C header files for non-gcc (/usr/include)")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_DATAROOTDIR)
+  set(CMAKE_INSTALL_DATAROOTDIR "share" CACHE PATH "read-only architecture-independent data root (share)")
+endif()
+
+#-----------------------------------------------------------------------------
+# Values whose defaults are relative to DATAROOTDIR.  Store empty values in
+# the cache and store the defaults in local variables if the cache values are
+# not set explicitly.  This auto-updates the defaults as DATAROOTDIR changes.
+
+if(NOT CMAKE_INSTALL_DATADIR)
+  set(CMAKE_INSTALL_DATADIR "" CACHE PATH "read-only architecture-independent data (DATAROOTDIR)")
+  set(CMAKE_INSTALL_DATADIR "${CMAKE_INSTALL_DATAROOTDIR}")
+endif()
+
+if(NOT CMAKE_INSTALL_INFODIR)
+  set(CMAKE_INSTALL_INFODIR "" CACHE PATH "info documentation (DATAROOTDIR/info)")
+  set(CMAKE_INSTALL_INFODIR "${CMAKE_INSTALL_DATAROOTDIR}/info")
+endif()
+
+if(NOT CMAKE_INSTALL_LOCALEDIR)
+  set(CMAKE_INSTALL_LOCALEDIR "" CACHE PATH "locale-dependent data (DATAROOTDIR/locale)")
+  set(CMAKE_INSTALL_LOCALEDIR "${CMAKE_INSTALL_DATAROOTDIR}/locale")
+endif()
+
+if(NOT CMAKE_INSTALL_MANDIR)
+  set(CMAKE_INSTALL_MANDIR "" CACHE PATH "man documentation (DATAROOTDIR/man)")
+  set(CMAKE_INSTALL_MANDIR "${CMAKE_INSTALL_DATAROOTDIR}/man")
+endif()
+
+if(NOT CMAKE_INSTALL_DOCDIR)
+  set(CMAKE_INSTALL_DOCDIR "" CACHE PATH "documentation root (DATAROOTDIR/doc/PROJECT_NAME)")
+  set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}")
+endif()
+
+#-----------------------------------------------------------------------------
+
+mark_as_advanced(
+  CMAKE_INSTALL_BINDIR
+  CMAKE_INSTALL_SBINDIR
+  CMAKE_INSTALL_LIBEXECDIR
+  CMAKE_INSTALL_SYSCONFDIR
+  CMAKE_INSTALL_SHAREDSTATEDIR
+  CMAKE_INSTALL_LOCALSTATEDIR
+  CMAKE_INSTALL_LIBDIR
+  CMAKE_INSTALL_INCLUDEDIR
+  CMAKE_INSTALL_OLDINCLUDEDIR
+  CMAKE_INSTALL_DATAROOTDIR
+  CMAKE_INSTALL_DATADIR
+  CMAKE_INSTALL_INFODIR
+  CMAKE_INSTALL_LOCALEDIR
+  CMAKE_INSTALL_MANDIR
+  CMAKE_INSTALL_DOCDIR
+  )
+
+# Result directories
+#
+foreach(dir
+    BINDIR
+    SBINDIR
+    LIBEXECDIR
+    SYSCONFDIR
+    SHAREDSTATEDIR
+    LOCALSTATEDIR
+    LIBDIR
+    INCLUDEDIR
+    OLDINCLUDEDIR
+    DATAROOTDIR
+    DATADIR
+    INFODIR
+    LOCALEDIR
+    MANDIR
+    DOCDIR
+    )
+  if(NOT IS_ABSOLUTE ${CMAKE_INSTALL_${dir}})
+    set(CMAKE_INSTALL_FULL_${dir} "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_${dir}}")
+  else()
+    set(CMAKE_INSTALL_FULL_${dir} "${CMAKE_INSTALL_${dir}}")
+  endif()
+endforeach()

--- a/cmake/gliBuildConfig.cmake.in
+++ b/cmake/gliBuildConfig.cmake.in
@@ -1,0 +1,6 @@
+set(GLI_VERSION "@GLI_VERSION@")
+set(GLI_INCLUDE_DIRS "@CMAKE_CURRENT_SOURCE_DIR@")
+
+if (NOT CMAKE_VERSION VERSION_LESS "3.0")
+    include("${CMAKE_CURRENT_LIST_DIR}/gliTargets.cmake")
+endif()

--- a/cmake/gliConfig.cmake.in
+++ b/cmake/gliConfig.cmake.in
@@ -1,0 +1,9 @@
+set(GLI_VERSION "@GLI_VERSION@")
+
+@PACKAGE_INIT@
+
+set_and_check(GLI_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+
+if (NOT CMAKE_VERSION VERSION_LESS "3.0")
+    include("${CMAKE_CURRENT_LIST_DIR}/gliTargets.cmake")
+endif()

--- a/gli/CMakeLists.txt
+++ b/gli/CMakeLists.txt
@@ -26,7 +26,9 @@ source_group("GTX Files" FILES ${GTX_HEADER})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-add_executable(${NAME} ${ROOT_TEXT} ${ROOT_MD} ${ROOT_KMG}
-	${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
-	${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
-	${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER})
+if(GLI_TEST_ENABLE)
+	add_executable(${NAME} ${ROOT_TEXT} ${ROOT_MD} ${ROOT_KMG}
+		${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
+		${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
+		${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER})
+endif(GLI_TEST_ENABLE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,12 @@
 function(glmCreateTestGTC NAME)
-	set(SAMPLE_NAME test-${NAME})
-	add_executable(${SAMPLE_NAME} ${NAME}.cpp)
-	add_test( 
-		NAME ${SAMPLE_NAME}
-		COMMAND $<TARGET_FILE:${SAMPLE_NAME}> )
+	if(GLI_TEST_ENABLE)
+		set(SAMPLE_NAME test-${NAME})
+		add_executable(${SAMPLE_NAME} ${NAME}.cpp)
+
+		add_test(
+			NAME ${SAMPLE_NAME}
+			COMMAND $<TARGET_FILE:${SAMPLE_NAME}> )
+	endif(GLI_TEST_ENABLE)
 endfunction()
 
 add_subdirectory(bug)


### PR DESCRIPTION
Fix #64

Now you can properly `sudo make install` gli.  Also, you don't need to build the tests to do so anymore (indeed, `GLI_TEST_ENABLE` is off by default).

Oh, uh, and the `.gitignore` is improved, too.