### PR TITLE
Fixed "use 'template' keyword to treat 'clear' as a dependent template name" error

### DIFF
--- a/gli/core/clear.inl
+++ b/gli/core/clear.inl
@@ -25,7 +25,7 @@ namespace gli
 		for(size_t FaceIndex = 0, FaceCount = Texture.faces(); FaceIndex < FaceCount; ++FaceIndex)
 		for(size_t LevelIndex = 0; LevelIndex < LevelCount; ++LevelIndex)
 		{
-			Texture.clear<gen_type>(LayerIndex, FaceIndex, BaseLevel + LevelIndex, BlockData);
+			Texture.template clear<gen_type>(LayerIndex, FaceIndex, BaseLevel + LevelIndex, BlockData);
 		}
 	}
 
@@ -42,7 +42,7 @@ namespace gli
 		for(size_t FaceIndex = 0; FaceIndex < FaceCount; ++FaceIndex)
 		for(size_t LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex)
 		{
-			Texture.clear<gen_type>(LayerIndex, BaseFace + FaceIndex, LevelIndex, BlockData);
+			Texture.template clear<gen_type>(LayerIndex, BaseFace + FaceIndex, LevelIndex, BlockData);
 		}
 	}
 
@@ -59,7 +59,7 @@ namespace gli
 		for(size_t FaceIndex = 0, FaceCount = Texture.faces(); FaceIndex < FaceCount; ++FaceIndex)
 		for(size_t LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex)
 		{
-			Texture.clear<gen_type>(LayerIndex + BaseLayer, FaceIndex, LevelIndex, BlockData);
+			Texture.template clear<gen_type>(LayerIndex + BaseLayer, FaceIndex, LevelIndex, BlockData);
 		}
 	}
 


### PR DESCRIPTION
Fixed "use 'template' keyword to treat 'clear' as a dependent template name" error while compiling.

Apple LLVM version 7.3.0 (clang-703.0.29)
Target: x86_64-apple-darwin15.4.0