### PR TITLE
Format helper functions and msvc errors

### DIFF
--- a/gli/core/file.inl
+++ b/gli/core/file.inl
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <glm/simd/platform.h>
+
+namespace gli{
+namespace detail
+{
+    inline FILE* open_file(const char *Filename, const char *Mode)
+    {
+    #if GLM_COMPILER & GLM_COMPILER_VC
+        FILE *File = nullptr;
+        fopen_s(&File, Filename, Mode);
+        return File;
+    #else
+        return std::fopen(Filename, Mode);
+    #endif
+    }
+}//namespace detail
+}//namespace gli

--- a/gli/core/format.inl
+++ b/gli/core/format.inl
@@ -316,4 +316,56 @@ namespace detail
 	{
 		return detail::get_format_info(Format).Component;
 	}
+
+	inline bool is_unsigned(format Format)
+	{
+		return detail::get_format_info(Format).Flags & detail::CAP_UNSIGNED_BIT ? true : false;
+	}
+
+	inline bool is_signed(format Format)
+	{
+		return detail::get_format_info(Format).Flags & detail::CAP_SIGNED_BIT ? true : false;
+	}
+
+	inline bool is_integer(format Format)
+	{
+		return detail::get_format_info(Format).Flags & detail::CAP_INTEGER_BIT ? true : false;
+	}
+
+	inline bool is_signed_integer(format Format)
+	{
+		return is_integer(Format) && is_signed(Format);
+	}
+
+	inline bool is_unsigned_integer(format Format)
+	{
+		return is_integer(Format) && is_unsigned(Format);
+	}
+
+	inline bool is_float(format Format)
+	{
+		return detail::get_format_info(Format).Flags & detail::CAP_FLOAT_BIT ? true : false;
+	}
+
+	inline bool is_normalized(format Format)
+	{
+		return detail::get_format_info(Format).Flags & detail::CAP_NORMALIZED_BIT ? true : false;
+	}
+
+	inline bool is_unorm(format Format)
+	{
+		return is_normalized(Format) && is_unsigned(Format);
+	}
+
+	inline bool is_snorm(format Format)
+	{
+		return is_normalized(Format) && is_signed(Format);
+	}
+
+	inline bool is_packed(format Format)
+	{
+		uint16_t flags = detail::get_format_info(Format).Flags;
+		
+		return (flags & detail::CAP_PACKED8_BIT) != 0 || (flags & detail::CAP_PACKED16_BIT) != 0 || (flags & detail::CAP_PACKED32_BIT) != 0;
+	}
 }//namespace gli

--- a/gli/core/load.inl
+++ b/gli/core/load.inl
@@ -1,6 +1,7 @@
 #include "../load_dds.hpp"
 #include "../load_kmg.hpp"
 #include "../load_ktx.hpp"
+#include "../file.hpp"
 
 namespace gli
 {
@@ -29,7 +30,7 @@ namespace gli
 	/// Load a texture (DDS, KTX or KMG) from file
 	inline texture load(char const * Filename)
 	{
-		FILE* File = std::fopen(Filename, "rb");
+		FILE* File = detail::open_file(Filename, "rb");
 		if(!File)
 			return texture();
 

--- a/gli/core/load_dds.inl
+++ b/gli/core/load_dds.inl
@@ -1,4 +1,5 @@
 #include "../dx.hpp"
+#include "../file.hpp"
 #include <cstdio>
 #include <cassert>
 
@@ -299,7 +300,7 @@ namespace detail
 
 	inline texture load_dds(char const * Filename)
 	{
-		FILE* File = std::fopen(Filename, "rb");
+		FILE* File = detail::open_file(Filename, "rb");
 		if(!File)
 			return texture();
 

--- a/gli/core/load_kmg.inl
+++ b/gli/core/load_kmg.inl
@@ -1,3 +1,4 @@
+#include "../file.hpp"
 #include <cstdio>
 #include <cassert>
 
@@ -78,7 +79,7 @@ namespace detail
 
 	inline texture load_kmg(char const * Filename)
 	{
-		FILE* File = std::fopen(Filename, "rb");
+		FILE* File = detail::open_file(Filename, "rb");
 		if(!File)
 			return texture();
 

--- a/gli/core/load_ktx.inl
+++ b/gli/core/load_ktx.inl
@@ -1,4 +1,5 @@
 #include "../gl.hpp"
+#include "../file.hpp"
 #include <cstdio>
 #include <cassert>
 
@@ -112,7 +113,7 @@ namespace detail
 
 	inline texture load_ktx(char const* Filename)
 	{
-		FILE* File = std::fopen(Filename, "rb");
+		FILE* File = detail::open_file(Filename, "rb");
 		if(!File)
 			return texture();
 

--- a/gli/core/save_dds.inl
+++ b/gli/core/save_dds.inl
@@ -1,5 +1,6 @@
 #include <cstdio>
 #include "../load_dds.hpp"
+#include "../file.hpp"
 
 namespace gli{
 namespace detail
@@ -118,7 +119,7 @@ namespace detail
 		if(Texture.empty())
 			return false;
 
-		FILE* File = std::fopen(Filename, "wb");
+		FILE* File = detail::open_file(Filename, "wb");
 		if(!File)
 			return false;
 

--- a/gli/core/save_kmg.inl
+++ b/gli/core/save_kmg.inl
@@ -2,6 +2,7 @@
 #include <glm/gtc/round.hpp>
 #include "../load_kmg.hpp"
 #include "../filter.hpp"
+#include "../file.hpp"
 
 namespace gli
 {
@@ -59,7 +60,7 @@ namespace gli
 		if(Texture.empty())
 			return false;
 
-		FILE* File = std::fopen(Filename, "wb");
+		FILE* File = detail::open_file(Filename, "wb");
 		if(!File)
 			return false;
 

--- a/gli/core/save_ktx.inl
+++ b/gli/core/save_ktx.inl
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <glm/gtc/round.hpp>
 #include "../load_ktx.hpp"
+#include "../file.hpp"
 
 namespace gli{
 namespace detail
@@ -93,7 +94,7 @@ namespace detail
 		if(Texture.empty())
 			return false;
 
-		FILE* File = std::fopen(Filename, "wb");
+		FILE* File = detail::open_file(Filename, "wb");
 		if(!File)
 			return false;
 

--- a/gli/file.hpp
+++ b/gli/file.hpp
@@ -1,0 +1,16 @@
+/// @brief File helper functions
+/// @file gli/file.hpp
+
+#pragma once
+
+#include <cstdio>
+
+namespace gli
+{
+    namespace detail
+    {
+        FILE* open_file(const char *Filename, const char *mode);
+    }//namespace detail
+}//namespace gli
+
+#include "./core/file.inl"

--- a/gli/format.hpp
+++ b/gli/format.hpp
@@ -301,6 +301,37 @@ namespace gli
 
 	/// Return the number of components of a format
 	size_t component_count(format Format);
+
+    /// Evaluate whether a format is unsigned
+    bool is_unsigned(format Format);
+
+    /// Evaluate whether a format is signed
+    bool is_signed(format Format);
+
+    /// Evaluate whether the format is an integer format
+    bool is_integer(format Format);
+
+    /// Evaluate whether the format is a signed integer format
+    bool is_signed_integer(format Format);
+
+    /// Evaluate whether the format is an unsigned integer format
+    bool is_unsigned_integer(format Format);
+
+    /// Evaluate whether the format is an float format
+    bool is_float(format Format);
+
+    /// Evaluate whether the format is normalized
+    bool is_normalized(format Format);
+
+    /// Evaluate whether the format is an unsigned normalized format
+    bool is_unorm(format Format);
+
+    /// Evaluate whether the format is a signed normalized format
+    bool is_snorm(format Format);
+
+    /// Evaluate whether the format is packed
+    bool is_packed(format Format);
+
 }//namespace gli
 
 #include "./core/format.inl"


### PR DESCRIPTION
Meant to split these two commits into two pull requests, but oh well. First commit is some additional helper functions for query info about a format. Second commit is for dealing with MSVC's wonder CRT secure errors.