### PR TITLE
Remove C++14 literals; fix some indentation

### DIFF
--- a/gli/core/flip.inl
+++ b/gli/core/flip.inl
@@ -16,7 +16,7 @@ namespace detail
 				LineSize);
 		}
 	}
-	
+
 	struct dxt1_block
 	{
 		uint16_t Color0;
@@ -58,7 +58,7 @@ namespace detail
 		uint8_t Row2;
 		uint8_t Row3;
 	};
-	
+
 	inline void flip_block_s3tc(uint8_t* BlockDst, uint8_t* BlockSrc, format Format, bool HeightTwo)
 	{
 		// There is no distinction between RGB and RGBA in DXT-compressed textures,
@@ -72,7 +72,7 @@ namespace detail
 		{
 			dxt1_block* Src = reinterpret_cast<dxt1_block*>(BlockSrc);
 			dxt1_block* Dst = reinterpret_cast<dxt1_block*>(BlockDst);
-	
+
 			if(HeightTwo)
 			{
 				Dst->Color0 = Src->Color0;
@@ -81,7 +81,7 @@ namespace detail
 				Dst->Row1 = Src->Row0;
 				Dst->Row2 = Src->Row2;
 				Dst->Row3 = Src->Row3;
-				
+
 				return;
 			}
 
@@ -91,7 +91,7 @@ namespace detail
 			Dst->Row1 = Src->Row2;
 			Dst->Row2 = Src->Row1;
 			Dst->Row3 = Src->Row0;
-				
+
 			return;
 		}
 
@@ -127,7 +127,7 @@ namespace detail
 			Dst->Row1 = Src->Row2;
 			Dst->Row2 = Src->Row1;
 			Dst->Row3 = Src->Row0;
-				
+
 			return;
 		}
 
@@ -142,9 +142,11 @@ namespace detail
 				Dst->Alpha0 = Src->Alpha0;
 				Dst->Alpha1 = Src->Alpha1;
 				// operator+ has precedence over operator>> and operator<<, hence the parentheses. very important!
-				Dst->AlphaR0 = ((Src->AlphaR1 & 0b11110000) >> 4) + ((Src->AlphaR2 & 0b1111) << 4);
-				Dst->AlphaR1 = ((Src->AlphaR2 & 0b11110000) >> 4) + ((Src->AlphaR0 & 0b1111) << 4);
-				Dst->AlphaR2 = ((Src->AlphaR0 & 0b11110000) >> 4) + ((Src->AlphaR1 & 0b1111) << 4);
+				// the values below are bitmasks used to retrieve alpha values according to the DXT specification
+				// 0xF0 == 0b11110000 and 0xF == 0b1111
+				Dst->AlphaR0 = ((Src->AlphaR1 & 0xF0) >> 4) + ((Src->AlphaR2 & 0xF) << 4);
+				Dst->AlphaR1 = ((Src->AlphaR2 & 0xF0) >> 4) + ((Src->AlphaR0 & 0xF) << 4);
+				Dst->AlphaR2 = ((Src->AlphaR0 & 0xF0) >> 4) + ((Src->AlphaR1 & 0xF) << 4);
 				Dst->AlphaR3 = Src->AlphaR3;
 				Dst->AlphaR4 = Src->AlphaR4;
 				Dst->AlphaR5 = Src->AlphaR5;
@@ -154,29 +156,31 @@ namespace detail
 				Dst->Row1 = Src->Row0;
 				Dst->Row2 = Src->Row2;
 				Dst->Row3 = Src->Row3;
-			
+
 				return;
 			}
 
 			Dst->Alpha0 = Src->Alpha0;
 			Dst->Alpha1 = Src->Alpha1;
 			// operator+ has precedence over operator>> and operator<<, hence the parentheses. very important!
-			Dst->AlphaR0 = ((Src->AlphaR4 & 0b11110000) >> 4) + ((Src->AlphaR5 & 0b1111) << 4);
-			Dst->AlphaR1 = ((Src->AlphaR5 & 0b11110000) >> 4) + ((Src->AlphaR3 & 0b1111) << 4);
-			Dst->AlphaR2 = ((Src->AlphaR3 & 0b11110000) >> 4) + ((Src->AlphaR4 & 0b1111) << 4);
-			Dst->AlphaR3 = ((Src->AlphaR1 & 0b11110000) >> 4) + ((Src->AlphaR2 & 0b1111) << 4);
-			Dst->AlphaR4 = ((Src->AlphaR2 & 0b11110000) >> 4) + ((Src->AlphaR0 & 0b1111) << 4);
-			Dst->AlphaR5 = ((Src->AlphaR0 & 0b11110000) >> 4) + ((Src->AlphaR1 & 0b1111) << 4);
+			// the values below are bitmasks used to retrieve alpha values according to the DXT specification
+			// 0xF0 == 0b11110000 and 0xF == 0b1111
+			Dst->AlphaR0 = ((Src->AlphaR4 & 0xF0) >> 4) + ((Src->AlphaR5 & 0xF) << 4);
+			Dst->AlphaR1 = ((Src->AlphaR5 & 0xF0) >> 4) + ((Src->AlphaR3 & 0xF) << 4);
+			Dst->AlphaR2 = ((Src->AlphaR3 & 0xF0) >> 4) + ((Src->AlphaR4 & 0xF) << 4);
+			Dst->AlphaR3 = ((Src->AlphaR1 & 0xF0) >> 4) + ((Src->AlphaR2 & 0xF) << 4);
+			Dst->AlphaR4 = ((Src->AlphaR2 & 0xF0) >> 4) + ((Src->AlphaR0 & 0xF) << 4);
+			Dst->AlphaR5 = ((Src->AlphaR0 & 0xF0) >> 4) + ((Src->AlphaR1 & 0xF) << 4);
 			Dst->Color0 = Src->Color0;
 			Dst->Color1 = Src->Color1;
 			Dst->Row0 = Src->Row3;
 			Dst->Row1 = Src->Row2;
 			Dst->Row2 = Src->Row1;
 			Dst->Row3 = Src->Row0;
-			
+
 			return;
 		}
-		
+
 		// invalid format specified (unknown S3TC format?)
 		assert(false);
 	}
@@ -186,8 +190,8 @@ namespace detail
 		if(ImageSrc.extent().y == 1)
 		{
 			memcpy(ImageDst.data(),
-				   ImageSrc.data(),
-				   ImageSrc.size());
+			       ImageSrc.data(),
+			       ImageSrc.size());
 			return;
 		}
 
@@ -196,7 +200,7 @@ namespace detail
 		{
 			for(std::size_t i_block = 0; i_block < XBlocks; ++i_block)
 				flip_block_s3tc(ImageDst.data<uint8_t>() + i_block * block_size(Format), ImageSrc.data<uint8_t>() + i_block * block_size(Format), Format, true);
-			
+
 			return;
 		}
 

--- a/test/core/core_flip.cpp
+++ b/test/core/core_flip.cpp
@@ -75,8 +75,8 @@ int main()
 
 	Error += test_texture(
 		gli::texture2d(gli::FORMAT_RGBA_DXT5_UNORM_BLOCK16, TextureSize, Levels),
-		gli::detail::dxt5_block{255, 0, 0b01000000, 0b00011110, 0b00110010, 0b00101101, 0b11110010, 0b01000100, 63712, 255, 228, 144, 64, 0},
-		gli::detail::dxt5_block{0, 255, 0b00111110, 0b10010000, 0b11100100, 0b11010110, 0b00111011, 0b11001000, 2516, 215, 152, 173, 215, 106});
+		gli::detail::dxt5_block{255, 0, 64, 30, 50, 45, 242, 68, 63712, 255, 228, 144, 64, 0},
+		gli::detail::dxt5_block{0, 255, 62, 144, 228, 214, 59, 200, 2516, 215, 152, 173, 215, 106});
 
 	return Error;
 }


### PR DESCRIPTION
I mistakenly added binary literals in #94. These are only supported in C++14 and so C++11-only compilers erred. Sorry about that! This fixes it.