### PR TITLE
Remove useless include_directories call in CMakeLists.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: cpp
 
 matrix:
@@ -24,6 +26,7 @@ compiler:
   - clang
 
 before_script: 
+- cmake --version
 
 script:
 - mkdir ./build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,11 +69,6 @@ macro(addExternalPackageGTC NAME DIRECTORY)
 endmacro(addExternalPackageGTC)
 
 ################################
-# Add External
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external)
-
-################################
 # Add subdirectory
 
 add_subdirectory(gli)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
-cmake_policy(VERSION 2.6)
-if (NOT CMAKE_VERSION VERSION_LESS "3.1")
-	cmake_policy(SET CMP0054 NEW)
-endif()
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_policy(SET CMP0054 NEW)
 
 project(gli)
 set(GLI_VERSION "0.8.2")
@@ -111,24 +108,22 @@ install(
 	DESTINATION ${GLI_INSTALL_CONFIGDIR}
 )
 
-if (NOT CMAKE_VERSION VERSION_LESS "3.0")
-	add_library(gli INTERFACE)
-	target_include_directories(gli INTERFACE
-		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external>
-	)
-	install(TARGETS gli EXPORT gliTargets)
+add_library(gli INTERFACE)
+target_include_directories(gli INTERFACE
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external>
+)
+install(TARGETS gli EXPORT gliTargets)
 
-	export(
-		EXPORT gliTargets
-		FILE "${CMAKE_CURRENT_BINARY_DIR}/gliTargets.cmake"
-	)
+export(
+	EXPORT gliTargets
+	FILE "${CMAKE_CURRENT_BINARY_DIR}/gliTargets.cmake"
+)
 
-	install(
-		EXPORT gliTargets FILE gliTargets.cmake
-		DESTINATION ${GLI_INSTALL_CONFIGDIR}
-	)
-endif()
+install(
+	EXPORT gliTargets FILE gliTargets.cmake
+	DESTINATION ${GLI_INSTALL_CONFIGDIR}
+)
 
 export(PACKAGE gli)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,8 +18,9 @@ function(glmCreateTestGTC NAME)
 
 	set(SAMPLE_NAME test-${NAME})
 	add_executable(${SAMPLE_NAME} ${NAME}.cpp)
+	target_link_libraries(${SAMPLE_NAME} gli)
 	add_test( 
-		NAME ${SAMPLE_NAME} ${GTX_INLINE} ${GTX_HEADER} ${CORE_INLINE} ${CORE_HEADER}
+		NAME ${SAMPLE_NAME}
 		COMMAND $<TARGET_FILE:${SAMPLE_NAME}> )
 endfunction()
 


### PR DESCRIPTION
**include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external)** is not required anymore since it is specified in **target_include_directories**.