### PR TITLE
Fix ordered comparison of pointer and zero in core_convert.cpp

### DIFF
--- a/test/core/core_convert.cpp
+++ b/test/core/core_convert.cpp
@@ -33,7 +33,7 @@ bool convert_rgb32f_rgb9e5(const char* FilenameSrc, const char* FilenameDst)
 {
 	if(FilenameDst == NULL)
 		return false;
-	if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
+	if(std::strstr(FilenameDst, ".dds") != nullptr || std::strstr(FilenameDst, ".ktx") != nullptr)
 		return false;
 
 	gli::texture2d TextureSource(gli::load(FilenameSrc));


### PR DESCRIPTION
The `core_convert.cpp` test currently contains a comparison of the result of `std::strstr` and zero using `>` which leads to a build failure using Clang 6 on macOS. This PR replaces the comparison with `!= nullptr` ones so the test compiles again. 