### PR TITLE
Fixed misspelled type

### DIFF
--- a/gli/core/bc.inl
+++ b/gli/core/bc.inl
@@ -78,7 +78,7 @@ namespace gli
 			ContiguousBitmap |= uint64_t(ChannelBitmap[3] | (ChannelBitmap[4] << 8) | (ChannelBitmap[5] << 16)) << 24;
 		}
 
-		inline void single_channel_bitmap_data_snorm(uint8_t Channel0, uint_t Channel1, bool Interpolate6, const uint8_t *ChannelBitmap, float *LookupTable, uint64_t &ContiguousBitmap)
+		inline void single_channel_bitmap_data_snorm(uint8_t Channel0, uint8_t Channel1, bool Interpolate6, const uint8_t *ChannelBitmap, float *LookupTable, uint64_t &ContiguousBitmap)
 		{
 			LookupTable[0] = (Channel0 / 255.0f) * 2.0f - 1.0f;
 			LookupTable[1] = (Channel1 / 255.0f) * 2.0f - 1.0f;


### PR DESCRIPTION
In one of the overloads of `gli::detail::single_channel_bitmap_data_snorm()` function, a `Channel1 `function parameter should be of type `int8_t`, not `int_t`.