### PR TITLE
load_dds - Fix for DX10 files with 64bpp

### DIFF
--- a/gli/core/load_dds.inl
+++ b/gli/core/load_dds.inl
@@ -183,7 +183,7 @@ namespace detail
 		dx DX;
 
 		gli::format Format(gli::FORMAT_UNDEFINED);
-		if((Header.Format.flags & (dx::DDPF_RGB | dx::DDPF_ALPHAPIXELS | dx::DDPF_ALPHA | dx::DDPF_YUV | dx::DDPF_LUMINANCE)) && Format == gli::FORMAT_UNDEFINED && Header.Format.bpp != 0)
+		if((Header.Format.flags & (dx::DDPF_RGB | dx::DDPF_ALPHAPIXELS | dx::DDPF_ALPHA | dx::DDPF_YUV | dx::DDPF_LUMINANCE)) && Format == gli::FORMAT_UNDEFINED && Header.Format.bpp > 0 && Header.Format.bpp < 64)
 		{
 			switch(Header.Format.bpp)
 			{


### PR DESCRIPTION
This condition was catching a 64bpp DX10 formatted file even though the switch statement wasn't handling it.  By passing on > 32 bit formats the following else if (I believe it was dx::D3DFMT_DX10) was able to process the file correclty.