### PR TITLE
MacOS - Add cast of 0 to pointer for comparison with pointer.

### DIFF
--- a/test/core/core_convert.cpp
+++ b/test/core/core_convert.cpp
@@ -33,7 +33,7 @@ bool convert_rgb32f_rgb9e5(const char* FilenameSrc, const char* FilenameDst)
 {
 	if(FilenameDst == NULL)
 		return false;
-	if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
+	if(std::strstr(FilenameDst, ".dds") > static_cast<void*>(0) || std::strstr(FilenameDst, ".ktx") > static_cast<void*>(0))
 		return false;
 
 	gli::texture2d TextureSource(gli::load(FilenameSrc));


### PR DESCRIPTION
This was triggering an error with clang on MacOS as a comparison between a pointer and an int.