### PR TITLE
Fix saving of dds cube maps with DX10 headers

### DIFF
--- a/gli/core/save_dds.inl
+++ b/gli/core/save_dds.inl
@@ -104,7 +104,7 @@ namespace detail
 
 			Header10.ArraySize = static_cast<std::uint32_t>(Texture.layers());
 			Header10.ResourceDimension = detail::get_dimension(Texture.target());
-			Header10.MiscFlag = 0;//Storage.levels() > 0 ? detail::D3D10_RESOURCE_MISC_GENERATE_MIPS : 0;
+			Header10.MiscFlag = Texture.faces() > 1 ? detail::D3D10_RESOURCE_MISC_TEXTURECUBE : 0;//Storage.levels() > 0 ? detail::D3D10_RESOURCE_MISC_GENERATE_MIPS : 0;
 			Header10.Format = DXFormat.DXGIFormat;
 			Header10.AlphaFlags = detail::DDS_ALPHA_MODE_UNKNOWN;
 		}


### PR DESCRIPTION
When writing a DX10 header for a cube map, D3D10_RESOURCE_MISC_TEXTURECUBE must be specified.