### PR TITLE
Compilation fixes

### DIFF
--- a/test/core/core_convert.cpp
+++ b/test/core/core_convert.cpp
@@ -33,7 +33,7 @@ bool convert_rgb32f_rgb9e5(const char* FilenameSrc, const char* FilenameDst)
 {
 	if(FilenameDst == NULL)
 		return false;
-	if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
+	if(std::strstr(FilenameDst, ".dds") || std::strstr(FilenameDst, ".ktx"))
 		return false;
 
 	gli::texture2d TextureSource(gli::load(FilenameSrc));


### PR DESCRIPTION
Fixing these compilation errors:
```
FAILED: 3rdparty/gli/test/core/CMakeFiles/test-core_convert.dir/core_convert.cpp.o 
/usr/bin/clang++  -DSOURCE_DIR=\".../3rdparty/gli\" -D_CRT_SECURE_NO_WARNINGS -I.../3rdparty/gli/. -I.../3rdparty/gli -I.../3rdparty/gli/external -g -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk   -Wall -std=c++11 -MD -MT 3rdparty/gli/test/core/CMakeFiles/test-core_convert.dir/core_convert.cpp.o -MF 3rdparty/gli/test/core/CMakeFiles/test-core_convert.dir/core_convert.cpp.o.d -o 3rdparty/gli/test/core/CMakeFiles/test-core_convert.dir/core_convert.cpp.o -c .../3rdparty/gli/test/core/core_convert.cpp
.../3rdparty/gli/test/core/core_convert.cpp:36:38: error: ordered comparison between pointer and zero ('const char *' and 'int')
        if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
.../3rdparty/gli/test/core/core_convert.cpp:36:78: error: ordered comparison between pointer and zero ('const char *' and 'int')
        if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
```

According to specs `std::strstr` returns either a pointer, or a `null`, so checking whether it's greater than zero seems to make little sense and is also a bad example of type conversion.

My local compiler is: Apple LLVM version 10.0.0 (clang-1000.11.45.5)