### PR TITLE
Optional building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 enable_testing()
+option(GLI_TEST_ENABLE "Build unit tests" ON)
 
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 add_definitions(-DSOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,10 +19,12 @@ function(glmCreateTestGTC NAME)
 	set(SAMPLE_NAME test-${NAME})
 	add_executable(${SAMPLE_NAME} ${NAME}.cpp)
 	target_link_libraries(${SAMPLE_NAME} gli)
-	add_test( 
+	add_test(
 		NAME ${SAMPLE_NAME}
 		COMMAND $<TARGET_FILE:${SAMPLE_NAME}> )
 endfunction()
 
-add_subdirectory(bug)
-add_subdirectory(core)
+if(GLI_TEST_ENABLE)
+	add_subdirectory(bug)
+	add_subdirectory(core)
+endif()


### PR DESCRIPTION
Copied the structure in GLM for the optinal testing.
Resolves issue: #143 
To disable the testing, use: `set(GLI_TEST_ENABLE OFF CACHE BOOL "" FORCE)`
before `add_subdirectory(path_to_gli)`