### PR TITLE
added D3D10_RESOURCE_MISC_TEXTURECUBE flag to dds dx10 header for cub…

### DIFF
--- a/gli/core/save_dds.inl
+++ b/gli/core/save_dds.inl
@@ -105,6 +105,8 @@ namespace detail
 			Header10.ArraySize = static_cast<std::uint32_t>(Texture.layers());
 			Header10.ResourceDimension = detail::get_dimension(Texture.target());
 			Header10.MiscFlag = 0;//Storage.levels() > 0 ? detail::D3D10_RESOURCE_MISC_GENERATE_MIPS : 0;
+			if (Texture.faces() > 1)
+				Header10.MiscFlag |= detail::d3d10_resource_misc_flag::D3D10_RESOURCE_MISC_TEXTURECUBE;
 			Header10.Format = DXFormat.DXGIFormat;
 			Header10.AlphaFlags = detail::DDS_ALPHA_MODE_UNKNOWN;
 		}


### PR DESCRIPTION
Some dds loaders ignore the cubemap flag in the base header and only look at the cubemap flag in the dx10 header (for example the [DirectX12TK DDSLoader](https://github.com/Microsoft/DirectXTK12/wiki/DDSTextureLoader)).