### PR TITLE
Fix: declaration of * hides class member

### DIFF
--- a/gli/core/gl.inl
+++ b/gli/core/gl.inl
@@ -327,13 +327,13 @@ namespace detail
 	{
 		GLI_ASSERT(Format >= FORMAT_FIRST && Format <= FORMAT_LAST);
 
-		gl::format_desc const& FormatDesc = this->FormatDesc[Format - FORMAT_FIRST];
+		gl::format_desc const& _FormatDesc = this->FormatDesc[Format - FORMAT_FIRST];
 
 		gl::format FormatGL;
-		FormatGL.Internal = FormatDesc.Internal;
-		FormatGL.External = FormatDesc.External;
-		FormatGL.Type = FormatDesc.Type;
-		FormatGL.Swizzles = this->compute_swizzle(FormatDesc, Swizzles);
+		FormatGL.Internal = _FormatDesc.Internal;
+		FormatGL.External = _FormatDesc.External;
+		FormatGL.Type = _FormatDesc.Type;
+		FormatGL.Swizzles = this->compute_swizzle(_FormatDesc, Swizzles);
 		return FormatGL;
 	}
 
@@ -354,12 +354,12 @@ namespace detail
 		return gli::FORMAT_UNDEFINED;
 	}
 
-	inline gl::swizzles gl::compute_swizzle(format_desc const& FormatDesc, gli::swizzles const& Swizzles) const
+	inline gl::swizzles gl::compute_swizzle(format_desc const& _FormatDesc, gli::swizzles const& Swizzles) const
 	{
 		if (!this->has_swizzle(this->Profile))
 			return swizzles(gl::SWIZZLE_RED, gl::SWIZZLE_GREEN, gl::SWIZZLE_BLUE, gl::SWIZZLE_ALPHA);
 
-		bool const IsExternalBGRA = ((FormatDesc.Properties & detail::FORMAT_PROPERTY_BGRA_FORMAT_BIT) && !has_swizzle(this->Profile)) || (FormatDesc.Properties & detail::FORMAT_PROPERTY_BGRA_TYPE_BIT);
+		bool const IsExternalBGRA = ((_FormatDesc.Properties & detail::FORMAT_PROPERTY_BGRA_FORMAT_BIT) && !has_swizzle(this->Profile)) || (_FormatDesc.Properties & detail::FORMAT_PROPERTY_BGRA_TYPE_BIT);
 
 		return detail::translate(IsExternalBGRA ? gli::swizzles(Swizzles.b, Swizzles.g, Swizzles.r, Swizzles.a) : Swizzles);
 	}

--- a/gli/core/image.inl
+++ b/gli/core/image.inl
@@ -103,11 +103,11 @@ namespace detail
 		format_type Format,
 		size_type BaseLayer,
 		size_type BaseFace,
-		size_type BaseLevel
+		size_type _BaseLevel
 	)
 		: Storage(Storage)
 		, Format(Format)
-		, BaseLevel(BaseLevel)
+		, BaseLevel(_BaseLevel)
 		, Data(compute_data(BaseLayer, BaseFace, BaseLevel))
 		, Size(compute_size(BaseLevel))
 	{}
@@ -213,9 +213,9 @@ namespace detail
 			*(this->data<genType>() + TexelIndex) = Texel;
 	}
 
-	inline image::data_type* image::compute_data(size_type BaseLayer, size_type BaseFace, size_type BaseLevel)
+	inline image::data_type* image::compute_data(size_type BaseLayer, size_type BaseFace, size_type _BaseLevel)
 	{
-		size_type const BaseOffset = this->Storage->base_offset(BaseLayer, BaseFace, BaseLevel);
+		size_type const BaseOffset = this->Storage->base_offset(BaseLayer, BaseFace, _BaseLevel);
 
 		return this->Storage->data() + BaseOffset;
 	}

--- a/gli/core/storage_linear.inl
+++ b/gli/core/storage_linear.inl
@@ -10,14 +10,14 @@ namespace gli
 		, Extent(0)
 	{}
 
-	inline storage_linear::storage_linear(format_type Format, extent_type const& Extent, size_type Layers, size_type Faces, size_type Levels)
+	inline storage_linear::storage_linear(format_type Format, extent_type const& _Extent, size_type Layers, size_type Faces, size_type Levels)
 		: Layers(Layers)
 		, Faces(Faces)
 		, Levels(Levels)
 		, BlockSize(gli::block_size(Format))
-		, BlockCount(glm::ceilMultiple(Extent, gli::block_extent(Format)) / gli::block_extent(Format))
+		, BlockCount(glm::ceilMultiple(_Extent, gli::block_extent(Format)) / gli::block_extent(Format))
 		, BlockExtent(gli::block_extent(Format))
-		, Extent(Extent)
+		, Extent(_Extent)
 	{
 		GLI_ASSERT(Layers > 0);
 		GLI_ASSERT(Faces > 0);
@@ -107,44 +107,44 @@ namespace gli
 		return BaseOffset;
 	}
 
-	inline storage_linear::size_type storage_linear::image_offset(extent1d const& Coord, extent1d const& Extent) const
+	inline storage_linear::size_type storage_linear::image_offset(extent1d const& Coord, extent1d const& _Extent) const
 	{
-		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent)));
+		GLI_ASSERT(glm::all(glm::lessThan(Coord, _Extent)));
 		return static_cast<size_t>(Coord.x);
 	}
 
-	inline storage_linear::size_type storage_linear::image_offset(extent2d const& Coord, extent2d const& Extent) const
+	inline storage_linear::size_type storage_linear::image_offset(extent2d const& Coord, extent2d const& _Extent) const
 	{
-		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent)));
-		return static_cast<size_t>(Coord.x + Coord.y * Extent.x);
+		GLI_ASSERT(glm::all(glm::lessThan(Coord, _Extent)));
+		return static_cast<size_t>(Coord.x + Coord.y * _Extent.x);
 	}
 
-	inline storage_linear::size_type storage_linear::image_offset(extent3d const& Coord, extent3d const& Extent) const
+	inline storage_linear::size_type storage_linear::image_offset(extent3d const& Coord, extent3d const& _Extent) const
 	{
-		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent)));
-		return static_cast<storage_linear::size_type>(Coord.x + Coord.y * Extent.x + Coord.z * Extent.x * Extent.y);
+		GLI_ASSERT(glm::all(glm::lessThan(Coord, _Extent)));
+		return static_cast<storage_linear::size_type>(Coord.x + Coord.y * _Extent.x + Coord.z * _Extent.x * _Extent.y);
 	}
 
 	inline void storage_linear::copy(
 		storage_linear const& StorageSrc,
 		size_t LayerSrc, size_t FaceSrc, size_t LevelSrc, extent_type const& BlockIndexSrc,
 		size_t LayerDst, size_t FaceDst, size_t LevelDst, extent_type const& BlockIndexDst,
-		extent_type const& BlockCount)
+		extent_type const& _BlockCount)
 	{
 		storage_linear::size_type const BaseOffsetSrc = StorageSrc.base_offset(LayerSrc, FaceSrc, LevelSrc);
 		storage_linear::size_type const BaseOffsetDst = this->base_offset(LayerDst, FaceDst, LevelDst);
 		storage_linear::data_type const* const ImageSrc = StorageSrc.data() + BaseOffsetSrc;
 		storage_linear::data_type* const ImageDst = this->data() + BaseOffsetDst;
 
-		for(size_t BlockIndexZ = 0, BlockCountZ = BlockCount.z; BlockIndexZ < BlockCountZ; ++BlockIndexZ)
-		for(size_t BlockIndexY = 0, BlockCountY = BlockCount.y; BlockIndexY < BlockCountY; ++BlockIndexY)
+		for(size_t BlockIndexZ = 0, BlockCountZ = _BlockCount.z; BlockIndexZ < BlockCountZ; ++BlockIndexZ)
+		for(size_t BlockIndexY = 0, BlockCountY = _BlockCount.y; BlockIndexY < BlockCountY; ++BlockIndexY)
 		{
 			extent_type const BlockIndex(0, BlockIndexY, BlockIndexZ);
 			gli::size_t const OffsetSrc = StorageSrc.image_offset(BlockIndexSrc + BlockIndex, StorageSrc.extent(LevelSrc)) * StorageSrc.block_size();
 			gli::size_t const OffsetDst = this->image_offset(BlockIndexDst + BlockIndex, this->extent(LevelDst)) * this->block_size();
 			storage_linear::data_type const* const DataSrc = ImageSrc + OffsetSrc;
 			storage_linear::data_type* DataDst = ImageDst + OffsetDst;
-			memcpy(DataDst, DataSrc, this->block_size() * BlockCount.x);
+			memcpy(DataDst, DataSrc, this->block_size() * _BlockCount.x);
 		}
 	}
 

--- a/gli/gl.hpp
+++ b/gli/gl.hpp
@@ -358,9 +358,9 @@ namespace gli
 			unsigned int Properties;
 		};
 
-		bool has_swizzle(profile Profile) const
+		bool has_swizzle(profile _Profile) const
 		{
-			return Profile == PROFILE_ES30 || Profile == PROFILE_GL33;
+			return _Profile == PROFILE_ES30 || _Profile == PROFILE_GL33;
 		}
 
 		gl::swizzles compute_swizzle(format_desc const& FormatDesc, gli::swizzles const& Swizzle) const;


### PR DESCRIPTION
On VS 2019 warning "C4458: declaration of '*' hides class member" . As result, projects that have -Werror can't compile due this warning.
