### PR TITLE
Expand Travis CI setup with additional compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ language: cpp
 branches:
   only:
     - master
-    - development
 
 compiler:
   - clang-3.9
   - clang   # clang 7
   - clang-9
   - clang-10
-  - gcc-4.9
+  - gcc-4.8
   - gcc     # gcc 7.4
   - gcc-9
   - gcc-10
@@ -53,17 +52,15 @@ jobs:
       env:
       - MATRIX_EVAL="CC=clang-10 CXX=clang++-10"
 
-    - compiler: gcc-4.9
-    - name: "Build with GCC 4.9"
+    - compiler: gcc-4.8
+    - name: "Build with GCC 4.8"
       addons:
         apt:
-          sources:
-          - ubuntu-toolchain-r-test
           packages:
-          - gcc-4.9
-          - g++-4.9
+          - gcc-4.8
+          - g++-4.8
       env:
-      - MATRIX_EVAL="CC=gcc-4.9 CXX=g++-4.9"
+      - MATRIX_EVAL="CC=gcc-4.8 CXX=g++-4.8"
 
     - compiler: gcc
     - name: "Build with GCC 7.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,8 @@ branches:
   only:
     - master
 
-compiler:
-  - clang-3.9
-  - clang   # clang 7
-  - clang-9
-  - clang-10
-  - gcc-4.8
-  - gcc     # gcc 7.4
-  - gcc-9
-  - gcc-10
-
 jobs:
   include:
-    - compiler: clang-3.9
     - name: "Build with LLVM/Clang 3.9"
       addons:
         apt:
@@ -26,12 +15,10 @@ jobs:
       env:
       - MATRIX_EVAL="CC=clang-3.9 CXX=clang++-3.9"
 
-    - compiler: clang
     - name: "Build with LLVM/Clang 7"
       env:
       - MATRIX_EVAL="CC=clang CXX=clang++"
 
-    - compiler: clang-9
     - name: "Build with LLVM/Clang 9"
       addons:
         apt:
@@ -40,7 +27,6 @@ jobs:
       env:
       - MATRIX_EVAL="CC=clang-9 CXX=clang++-9"
 
-    - compiler: clang-10
     - name: "Build with LLVM/Clang 10"
       addons:
         apt:
@@ -52,7 +38,6 @@ jobs:
       env:
       - MATRIX_EVAL="CC=clang-10 CXX=clang++-10"
 
-    - compiler: gcc-4.8
     - name: "Build with GCC 4.8"
       addons:
         apt:
@@ -62,12 +47,10 @@ jobs:
       env:
       - MATRIX_EVAL="CC=gcc-4.8 CXX=g++-4.8"
 
-    - compiler: gcc
     - name: "Build with GCC 7.4"
       env:
       - MATRIX_EVAL="CC=gcc CXX=g++"
 
-    - compiler: gcc-9
     - name: "Build with GCC 9"
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ compiler:
 
 jobs:
   include:
-      - compiler: clang-3.9
+    - compiler: clang-3.9
     - name: "Build with LLVM/Clang 3.9"
       addons:
         apt:
           packages:
           - clang-3.9
-     env:
+      env:
       - MATRIX_EVAL="CC=clang-3.9 CXX=clang++-3.9"
 
     - compiler: clang
@@ -107,4 +107,3 @@ script:
 - cmake --build .
 - ctest
 - cd ..
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ jobs:
       env:
       - MATRIX_EVAL="CC=gcc-9 CXX=g++-9"
 
-    - compiler: gcc-10
     - name: "Build with GCC 10"
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,109 @@
-dist: trusty
-
+dist: bionic
 language: cpp
 
-matrix:
-  include:
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env: COMPILER=g++-4.9
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-          packages:
-            - clang-3.8
-      env: COMPILER=clang++-3.8
+branches:
+  only:
+    - master
+    - development
 
 compiler:
-  - clang
+  - clang-3.9
+  - clang   # clang 7
+  - clang-9
+  - clang-10
+  - gcc-4.9
+  - gcc     # gcc 7.4
+  - gcc-9
+  - gcc-10
+
+jobs:
+  include:
+      - compiler: clang-3.9
+    - name: "Build with LLVM/Clang 3.9"
+      addons:
+        apt:
+          packages:
+          - clang-3.9
+     env:
+      - MATRIX_EVAL="CC=clang-3.9 CXX=clang++-3.9"
+
+    - compiler: clang
+    - name: "Build with LLVM/Clang 7"
+      env:
+      - MATRIX_EVAL="CC=clang CXX=clang++"
+
+    - compiler: clang-9
+    - name: "Build with LLVM/Clang 9"
+      addons:
+        apt:
+          packages:
+          - clang-9
+      env:
+      - MATRIX_EVAL="CC=clang-9 CXX=clang++-9"
+
+    - compiler: clang-10
+    - name: "Build with LLVM/Clang 10"
+      addons:
+        apt:
+          sources:
+          - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+          key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+          - clang-10
+      env:
+      - MATRIX_EVAL="CC=clang-10 CXX=clang++-10"
+
+    - compiler: gcc-4.9
+    - name: "Build with GCC 4.9"
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-4.9
+          - g++-4.9
+      env:
+      - MATRIX_EVAL="CC=gcc-4.9 CXX=g++-4.9"
+
+    - compiler: gcc
+    - name: "Build with GCC 7.4"
+      env:
+      - MATRIX_EVAL="CC=gcc CXX=g++"
+
+    - compiler: gcc-9
+    - name: "Build with GCC 9"
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-9
+          - g++-9
+      env:
+      - MATRIX_EVAL="CC=gcc-9 CXX=g++-9"
+
+    - compiler: gcc-10
+    - name: "Build with GCC 10"
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-10
+          - g++-10
+      env:
+      - MATRIX_EVAL="CC=gcc-10 CXX=g++-10"
 
 before_script: 
 - cmake --version
+- eval "${MATRIX_EVAL}"
+- $CC --version
+- $CXX --version
 
 script:
 - mkdir ./build
 - cd ./build
-- cmake -DCMAKE_CXX_COMPILER=$COMPILER ..
+- cmake ..
 - cmake --build .
 - ctest
 - cd ..

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ GLuint CreateTexture(char const* Filename)
 
 | Service | System | Compiler | Status |
 | ------- | ------ | -------- | ------ |
-| [Travis CI](https://travis-ci.org/g-truc/gli)| Linux 64 bits | Clang 3.4, Clang 3.8, GCC 4.9 | [![Travis CI](https://travis-ci.org/g-truc/gli.svg?branch=master)](https://travis-ci.org/g-truc/gli)
+| [Travis CI](https://travis-ci.org/g-truc/gli)| Linux 64 bits | Clang 3.9, Clang 7, Clang 9, Clang 10, GCC 4.9, GCC 7.4, GCC 9, GCC 10 | [![Travis CI](https://travis-ci.org/g-truc/gli.svg?branch=master)](https://travis-ci.org/g-truc/gli)
 | [AppVeyor](https://ci.appveyor.com/project/Groovounet/gli)| Windows 32 and 64 | Visual Studio 2013 | [![AppVeyor](https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?svg=true)](https://ci.appveyor.com/project/Groovounet/gli)
 
 ## Release notes

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ GLuint CreateTexture(char const* Filename)
 
 | Service | System | Compiler | Status |
 | ------- | ------ | -------- | ------ |
-| [Travis CI](https://travis-ci.org/g-truc/gli)| Linux 64 bits | Clang 3.9, Clang 7, Clang 9, Clang 10, GCC 4.9, GCC 7.4, GCC 9, GCC 10 | [![Travis CI](https://travis-ci.org/g-truc/gli.svg?branch=master)](https://travis-ci.org/g-truc/gli)
+| [Travis CI](https://travis-ci.org/g-truc/gli)| Linux 64 bits | Clang 3.9, Clang 7, Clang 9, Clang 10, GCC 4.8, GCC 7.4, GCC 9, GCC 10 | [![Travis CI](https://travis-ci.org/g-truc/gli.svg?branch=master)](https://travis-ci.org/g-truc/gli)
 | [AppVeyor](https://ci.appveyor.com/project/Groovounet/gli)| Windows 32 and 64 | Visual Studio 2013 | [![AppVeyor](https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?svg=true)](https://ci.appveyor.com/project/Groovounet/gli)
 
 ## Release notes


### PR DESCRIPTION
Adds additional GCC and Clang versions to the Travis CI YAML.

Unfortunately, Clang 3.4 is no longer in Ubuntu 18.04 repos, nor in the repos provided by LLVM.