### PR TITLE
Correctly calculate pitch when saving dds

### DIFF
--- a/gli/core/save_dds.inl
+++ b/gli/core/save_dds.inl
@@ -68,16 +68,16 @@ namespace detail
 		//Caps |= Storage.levels() > 1 ? detail::DDSD_MIPMAPCOUNT : 0;
 		Caps |= (Desc.Flags & detail::CAP_COMPRESSED_BIT) ? detail::DDSD_LINEARSIZE : detail::DDSD_PITCH;
 
-		std::uint32_t Pitch = 0u;
+		std::uint32_t PitchInBytes = 0u;
 		if( ( Desc.Flags & detail::CAP_COMPRESSED_BIT ) )
 		{
-			Pitch = static_cast<std::uint32_t>(Texture.size() / Texture.faces());
+			PitchInBytes = static_cast<std::uint32_t>(Texture.size() / Texture.faces());
 		}
 		else
 		{
 			const texture::extent_type& TextureExtent = Texture.extent();
-			const std::uint32_t PixelSizeInBytes = detail::bits_per_pixel( Texture.format() ) / 8u;
-			Pitch = TextureExtent.x * PixelSizeInBytes;
+			const std::uint32_t BitsPerPixel = detail::bits_per_pixel( Texture.format() );
+			PitchInBytes = ( TextureExtent.x * BitsPerPixel ) / 8u;
 		}
 
 		memset(Header.Reserved1, 0, sizeof(Header.Reserved1));
@@ -86,7 +86,7 @@ namespace detail
 		Header.Flags = Caps;
 		Header.Width = static_cast<std::uint32_t>(Texture.extent().x);
 		Header.Height = static_cast<std::uint32_t>(Texture.extent().y);
-		Header.Pitch = Pitch;
+		Header.Pitch = PitchInBytes;
 		Header.Depth = static_cast<std::uint32_t>(Texture.extent().z > 1 ? Texture.extent().z : 0);
 		Header.MipMapLevels = static_cast<std::uint32_t>(Texture.levels());
 		Header.Format.size = sizeof(detail::dds_pixel_format);

--- a/gli/core/save_dds.inl
+++ b/gli/core/save_dds.inl
@@ -68,13 +68,25 @@ namespace detail
 		//Caps |= Storage.levels() > 1 ? detail::DDSD_MIPMAPCOUNT : 0;
 		Caps |= (Desc.Flags & detail::CAP_COMPRESSED_BIT) ? detail::DDSD_LINEARSIZE : detail::DDSD_PITCH;
 
+		std::uint32_t Pitch = 0u;
+		if( ( Desc.Flags & detail::CAP_COMPRESSED_BIT ) )
+		{
+			Pitch = static_cast<std::uint32_t>(Texture.size() / Texture.faces());
+		}
+		else
+		{
+			const texture::extent_type& TextureExtent = Texture.extent();
+			const std::uint32_t PixelSizeInBytes = detail::bits_per_pixel( Texture.format() ) / 8u;
+			Pitch = TextureExtent.x * PixelSizeInBytes;
+		}
+
 		memset(Header.Reserved1, 0, sizeof(Header.Reserved1));
 		memset(Header.Reserved2, 0, sizeof(Header.Reserved2));
 		Header.Size = sizeof(detail::dds_header);
 		Header.Flags = Caps;
 		Header.Width = static_cast<std::uint32_t>(Texture.extent().x);
 		Header.Height = static_cast<std::uint32_t>(Texture.extent().y);
-		Header.Pitch = static_cast<std::uint32_t>((Desc.Flags & detail::CAP_COMPRESSED_BIT) ? Texture.size() / Texture.faces() : 32);
+		Header.Pitch = Pitch;
 		Header.Depth = static_cast<std::uint32_t>(Texture.extent().z > 1 ? Texture.extent().z : 0);
 		Header.MipMapLevels = static_cast<std::uint32_t>(Texture.levels());
 		Header.Format.size = sizeof(detail::dds_pixel_format);

--- a/gli/save_dds.hpp
+++ b/gli/save_dds.hpp
@@ -7,7 +7,7 @@
 
 namespace gli
 {
-	/// Save a texture storage_linear to a DDS file.
+	/// Save a texture storage_linear to a DDS file. We're assuming that the pixel data is tighty packed
 	///
 	/// @param Texture Source texture to save
 	/// @param Path Path for where to save the file. It must include the filaname and filename extension.
@@ -15,7 +15,7 @@ namespace gli
 	/// @return Returns false if the function fails to save the file.
 	bool save_dds(texture const & Texture, char const* Path);
 
-	/// Save a texture storage_linear to a DDS file.
+	/// Save a texture storage_linear to a DDS file. We're assuming that the pixel data is tighty packed
 	///
 	/// @param Texture Source texture to save
 	/// @param Path Path for where to save the file. It must include the filaname and filename extension.
@@ -23,7 +23,7 @@ namespace gli
 	/// @return Returns false if the function fails to save the file.
 	bool save_dds(texture const & Texture, std::string const & Path);
 
-	/// Save a texture storage_linear to a DDS file.
+	/// Save a texture storage_linear to a DDS file. We're assuming that the pixel data is tighty packed
 	///
 	/// @param Texture Source texture to save
 	/// @param Memory Storage for the DDS container. The function resizes the containers to fit the necessary storage_linear.


### PR DESCRIPTION
Instead of assuming a pitch of 32 bytes, calculate the pitch for uncompressed textures as if the pixel data is tightly packed.
Also added note in the function description that the pixel data is assumed to be tightly packed.