### PR TITLE
Add DDSCAPS_COMPLEX when saving .dds files

### DIFF
--- a/gli/core/save_dds.inl
+++ b/gli/core/save_dds.inl
@@ -95,7 +95,7 @@ namespace detail
 		Header.Format.bpp = static_cast<std::uint32_t>(detail::bits_per_pixel(Texture.format()));
 		Header.Format.Mask = DXFormat.Mask;
 		//Header.surfaceFlags = detail::DDSCAPS_TEXTURE | (Storage.levels() > 1 ? detail::DDSCAPS_MIPMAP : 0);
-		Header.SurfaceFlags = detail::DDSCAPS_TEXTURE | detail::DDSCAPS_MIPMAP;
+		Header.SurfaceFlags = detail::DDSCAPS_TEXTURE | detail::DDSCAPS_MIPMAP | detail::DDSCAPS_COMPLEX;
 		Header.CubemapFlags = 0;
 
 		// Cubemap


### PR DESCRIPTION
Hello,

I use RenderDoc to view .dds files. I was using gli to generate a .dds file that contains a mipmap chain of cubemaps, and I noticed that my file wasn't being detected as a cubemap in RenderDoc (eventhough the files generated by [cfmt](https://github.com/dariomanesku/cmft) where recognized correctly).

So I researched how they do it in cmft: https://github.com/dariomanesku/cmft/blob/cad5f31bac66fd05987d667af62311c444df6d46/src/cmft/image.cpp#L1113

Apparently, having mipmaps or having cubemaps implies the flag DDSCAPS_COMPLEX. I would have never figured that out from the [documentation](https://docs.microsoft.com/en-us/previous-versions/windows/hardware/drivers/ff550286(v=vs.85)).

With this small change RenderDoc seems to recognize the generated files correctly.