### PR TITLE
Remove warnings

### DIFF
--- a/gli/core/duplicate.inl
+++ b/gli/core/duplicate.inl
@@ -218,6 +218,7 @@ namespace detail
 		texture_cube::size_type BaseLevel, texture_cube::size_type MaxLevel
 	)
 	{
+		GLI_UNUSED(MaxFace);
 		GLI_ASSERT(BaseLevel >= 0 && BaseLevel < Texture.levels() && BaseLevel <= MaxLevel && MaxLevel < Texture.levels());
 		GLI_ASSERT(BaseFace <= MaxFace);
 		GLI_ASSERT(BaseFace < Texture.faces());
@@ -242,6 +243,7 @@ namespace detail
 		texture_cube_array::size_type BaseLevel, texture_cube_array::size_type MaxLevel
 	)
 	{
+		GLI_UNUSED(MaxFace);
 		GLI_ASSERT(BaseLevel <= MaxLevel);
 		GLI_ASSERT(BaseLevel < Texture.levels());
 		GLI_ASSERT(MaxLevel < Texture.levels());

--- a/gli/core/format.inl
+++ b/gli/core/format.inl
@@ -283,7 +283,7 @@ namespace detail
 		GLI_ASSERT(Format != FORMAT_UNDEFINED);
 
 		return Table[Format - FORMAT_FIRST];
-	};
+	}
 
 	inline std::uint32_t bits_per_pixel(format Format)
 	{

--- a/gli/core/format.inl
+++ b/gli/core/format.inl
@@ -375,7 +375,7 @@ namespace detail
 
 	inline bool is_packed(format Format)
 	{
-		gli::uint16 flags = detail::get_format_info(Format).Flags;
+		gli::uint32 flags = detail::get_format_info(Format).Flags;
 
 		return (flags & detail::CAP_PACKED8_BIT) != 0 || (flags & detail::CAP_PACKED16_BIT) != 0 || (flags & detail::CAP_PACKED32_BIT) != 0;
 	}

--- a/gli/core/gl.inl
+++ b/gli/core/gl.inl
@@ -327,13 +327,13 @@ namespace detail
 	{
 		GLI_ASSERT(Format >= FORMAT_FIRST && Format <= FORMAT_LAST);
 
-		gl::format_desc const& FormatDesc = this->FormatDesc[Format - FORMAT_FIRST];
+		gl::format_desc const& FormatDesc_ = this->FormatDesc[Format - FORMAT_FIRST];
 
 		gl::format FormatGL;
-		FormatGL.Internal = FormatDesc.Internal;
-		FormatGL.External = FormatDesc.External;
-		FormatGL.Type = FormatDesc.Type;
-		FormatGL.Swizzles = this->compute_swizzle(FormatDesc, Swizzles);
+		FormatGL.Internal = FormatDesc_.Internal;
+		FormatGL.External = FormatDesc_.External;
+		FormatGL.Type = FormatDesc_.Type;
+		FormatGL.Swizzles = this->compute_swizzle(FormatDesc_, Swizzles);
 		return FormatGL;
 	}
 
@@ -354,12 +354,12 @@ namespace detail
 		return gli::FORMAT_UNDEFINED;
 	}
 
-	inline gl::swizzles gl::compute_swizzle(format_desc const& FormatDesc, gli::swizzles const& Swizzles) const
+	inline gl::swizzles gl::compute_swizzle(format_desc const& FormatDesc_, gli::swizzles const& Swizzles) const
 	{
 		if (!this->has_swizzle(this->Profile))
 			return swizzles(gl::SWIZZLE_RED, gl::SWIZZLE_GREEN, gl::SWIZZLE_BLUE, gl::SWIZZLE_ALPHA);
 
-		bool const IsExternalBGRA = ((FormatDesc.Properties & detail::FORMAT_PROPERTY_BGRA_FORMAT_BIT) && !has_swizzle(this->Profile)) || (FormatDesc.Properties & detail::FORMAT_PROPERTY_BGRA_TYPE_BIT);
+		bool const IsExternalBGRA = ((FormatDesc_.Properties & detail::FORMAT_PROPERTY_BGRA_FORMAT_BIT) && !has_swizzle(this->Profile)) || (FormatDesc_.Properties & detail::FORMAT_PROPERTY_BGRA_TYPE_BIT);
 
 		return detail::translate(IsExternalBGRA ? gli::swizzles(Swizzles.b, Swizzles.g, Swizzles.r, Swizzles.a) : Swizzles);
 	}

--- a/gli/core/image.inl
+++ b/gli/core/image.inl
@@ -7,6 +7,7 @@ namespace detail
 		extent1d const& TexelCoord
 	)
 	{
+		GLI_UNUSED(Extent);
 		GLI_ASSERT(glm::all(glm::lessThan(TexelCoord, Extent)));
 
 		return static_cast<size_t>(TexelCoord.x);
@@ -43,6 +44,7 @@ namespace detail
 		extent1d const& TexelCoord
 	)
 	{
+		GLI_UNUSED(Extent);
 		GLI_ASSERT(TexelCoord.x < Extent.x);
 
 		return TexelCoord.x;
@@ -54,6 +56,7 @@ namespace detail
 		extent2d const& TexelCoord
 	)
 	{
+		GLI_UNUSED(Extent);
 		GLI_ASSERT(TexelCoord.x < Extent.x && TexelCoord.x >= 0 && TexelCoord.x < std::numeric_limits<extent2d::value_type>::max());
 		GLI_ASSERT(TexelCoord.y < Extent.y && TexelCoord.y >= 0 && TexelCoord.y < std::numeric_limits<extent2d::value_type>::max());
 
@@ -68,6 +71,7 @@ namespace detail
 		extent3d const& TexelCoord
 	)
 	{
+		GLI_UNUSED(Extent);
 		GLI_ASSERT(TexelCoord.x < Extent.x);
 		GLI_ASSERT(TexelCoord.y < Extent.y);
 		GLI_ASSERT(TexelCoord.z < Extent.z);
@@ -213,9 +217,9 @@ namespace detail
 			*(this->data<genType>() + TexelIndex) = Texel;
 	}
 
-	inline image::data_type* image::compute_data(size_type BaseLayer, size_type BaseFace, size_type BaseLevel)
+	inline image::data_type* image::compute_data(size_type BaseLayer, size_type BaseFace, size_type BaseLevel_)
 	{
-		size_type const BaseOffset = this->Storage->base_offset(BaseLayer, BaseFace, BaseLevel);
+		size_type const BaseOffset = this->Storage->base_offset(BaseLayer, BaseFace, BaseLevel_);
 
 		return this->Storage->data() + BaseOffset;
 	}

--- a/gli/core/load_dds.inl
+++ b/gli/core/load_dds.inl
@@ -162,6 +162,7 @@ namespace detail
 
 	inline texture load_dds(char const * Data, std::size_t Size)
 	{
+		GLI_UNUSED(Size);
 		GLI_ASSERT(Data && (Size >= sizeof(detail::FOURCC_DDS)));
 
 		if(strncmp(Data, detail::FOURCC_DDS, 4) != 0)
@@ -293,6 +294,7 @@ namespace detail
 			std::max<texture::size_type>(Header10.ArraySize, 1), FaceCount, MipMapCount);
 
 		std::size_t const SourceSize = Offset + Texture.size();
+		GLI_UNUSED(SourceSize);
 		GLI_ASSERT(SourceSize == Size);
 
 		std::memcpy(Texture.data(), Data + Offset, Texture.size());

--- a/gli/core/load_kmg.inl
+++ b/gli/core/load_kmg.inl
@@ -29,6 +29,7 @@ namespace detail
 
 	inline texture load_kmg100(char const * Data, std::size_t Size)
 	{
+		GLI_UNUSED(Size);
 		detail::kmgHeader10 const & Header(*reinterpret_cast<detail::kmgHeader10 const *>(Data));
 
 		size_t Offset = sizeof(detail::kmgHeader10);

--- a/gli/core/load_ktx.inl
+++ b/gli/core/load_ktx.inl
@@ -50,8 +50,10 @@ namespace detail
 			return TARGET_2D;
 	}
 
-	inline texture load_ktx10(char const* Data, std::size_t Size)
+	inline texture load_ktx10(char const* Data, std::size_t Size )
 	{
+		(void)Size; // parameter unused
+
 		detail::ktx_header10 const & Header(*reinterpret_cast<detail::ktx_header10 const*>(Data));
 
 		size_t Offset = sizeof(detail::ktx_header10);

--- a/gli/core/save_dds.inl
+++ b/gli/core/save_dds.inl
@@ -102,7 +102,7 @@ namespace detail
 		if(Texture.faces() > 1)
 		{
 			GLI_ASSERT(Texture.faces() == 6);
-			Header.CubemapFlags |= detail::DDSCAPS2_CUBEMAP_ALLFACES | detail::DDSCAPS2_CUBEMAP;
+			Header.CubemapFlags |= (glm::uint32)detail::DDSCAPS2_CUBEMAP_ALLFACES | detail::DDSCAPS2_CUBEMAP;
 		}
 
 		// Texture3D

--- a/gli/core/storage_linear.inl
+++ b/gli/core/storage_linear.inl
@@ -107,44 +107,45 @@ namespace gli
 		return BaseOffset;
 	}
 
-	inline storage_linear::size_type storage_linear::image_offset(extent1d const& Coord, extent1d const& Extent) const
+	inline storage_linear::size_type storage_linear::image_offset(extent1d const& Coord, extent1d const& Extent_) const
 	{
-		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent)));
+		GLI_UNUSED(Extent_);
+		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent_)));
 		return static_cast<size_t>(Coord.x);
 	}
 
-	inline storage_linear::size_type storage_linear::image_offset(extent2d const& Coord, extent2d const& Extent) const
+	inline storage_linear::size_type storage_linear::image_offset(extent2d const& Coord, extent2d const& Extent_) const
 	{
-		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent)));
-		return static_cast<size_t>(Coord.x + Coord.y * Extent.x);
+		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent_)));
+		return static_cast<size_t>(Coord.x + Coord.y * Extent_.x);
 	}
 
-	inline storage_linear::size_type storage_linear::image_offset(extent3d const& Coord, extent3d const& Extent) const
+	inline storage_linear::size_type storage_linear::image_offset(extent3d const& Coord, extent3d const& Extent_) const
 	{
-		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent)));
-		return static_cast<storage_linear::size_type>(Coord.x + Coord.y * Extent.x + Coord.z * Extent.x * Extent.y);
+		GLI_ASSERT(glm::all(glm::lessThan(Coord, Extent_)));
+		return static_cast<storage_linear::size_type>(Coord.x + Coord.y * Extent_.x + Coord.z * Extent_.x * Extent_.y);
 	}
 
 	inline void storage_linear::copy(
 		storage_linear const& StorageSrc,
 		size_t LayerSrc, size_t FaceSrc, size_t LevelSrc, extent_type const& BlockIndexSrc,
 		size_t LayerDst, size_t FaceDst, size_t LevelDst, extent_type const& BlockIndexDst,
-		extent_type const& BlockCount)
+		extent_type const& BlockCount_)
 	{
 		storage_linear::size_type const BaseOffsetSrc = StorageSrc.base_offset(LayerSrc, FaceSrc, LevelSrc);
 		storage_linear::size_type const BaseOffsetDst = this->base_offset(LayerDst, FaceDst, LevelDst);
 		storage_linear::data_type const* const ImageSrc = StorageSrc.data() + BaseOffsetSrc;
 		storage_linear::data_type* const ImageDst = this->data() + BaseOffsetDst;
 
-		for(size_t BlockIndexZ = 0, BlockCountZ = BlockCount.z; BlockIndexZ < BlockCountZ; ++BlockIndexZ)
-		for(size_t BlockIndexY = 0, BlockCountY = BlockCount.y; BlockIndexY < BlockCountY; ++BlockIndexY)
+		for(size_t BlockIndexZ = 0, BlockCountZ = BlockCount_.z; BlockIndexZ < BlockCountZ; ++BlockIndexZ)
+		for(size_t BlockIndexY = 0, BlockCountY = BlockCount_.y; BlockIndexY < BlockCountY; ++BlockIndexY)
 		{
 			extent_type const BlockIndex(0, BlockIndexY, BlockIndexZ);
 			gli::size_t const OffsetSrc = StorageSrc.image_offset(BlockIndexSrc + BlockIndex, StorageSrc.extent(LevelSrc)) * StorageSrc.block_size();
 			gli::size_t const OffsetDst = this->image_offset(BlockIndexDst + BlockIndex, this->extent(LevelDst)) * this->block_size();
 			storage_linear::data_type const* const DataSrc = ImageSrc + OffsetSrc;
 			storage_linear::data_type* DataDst = ImageDst + OffsetDst;
-			memcpy(DataDst, DataSrc, this->block_size() * BlockCount.x);
+			memcpy(DataDst, DataSrc, this->block_size() * BlockCount_.x);
 		}
 	}
 

--- a/gli/core/view.inl
+++ b/gli/core/view.inl
@@ -136,6 +136,7 @@ namespace gli
 		texture_cube::size_type BaseLevel, texture_cube::size_type MaxLevel
 	)
 	{
+		GLI_UNUSED(BaseFace);
 		GLI_ASSERT(!Texture.empty());
 		GLI_ASSERT(BaseLevel >= 0 && BaseLevel < Texture.levels() && MaxLevel >= 0 && MaxLevel < Texture.levels() && BaseLevel <= MaxLevel);
 		GLI_ASSERT(BaseFace >= 0 && BaseFace < Texture.faces() && MaxFace >= 0 && MaxFace < Texture.faces() && BaseFace <= MaxFace);

--- a/gli/gl.hpp
+++ b/gli/gl.hpp
@@ -358,9 +358,9 @@ namespace gli
 			unsigned int Properties;
 		};
 
-		bool has_swizzle(profile Profile) const
+		bool has_swizzle(profile Profile_) const
 		{
-			return Profile == PROFILE_ES30 || Profile == PROFILE_GL33;
+			return Profile_ == PROFILE_ES30 || Profile_ == PROFILE_GL33;
 		}
 
 		gl::swizzles compute_swizzle(format_desc const& FormatDesc, gli::swizzles const& Swizzle) const;

--- a/gli/type.hpp
+++ b/gli/type.hpp
@@ -28,6 +28,8 @@
 #	define GLI_ASSERT(test) assert((test))
 #endif
 
+#define GLI_UNUSED(x) (void)(x)
+
 namespace gli
 {
 	using namespace glm;


### PR DESCRIPTION
Warnings fixed (MSVC warning codes under /W4):
core/format.inl(378,21): warning C4244: 'initializing': conversion from 'const glm::uint32' to 'glm::uint16', possible loss of data
core\storage_linear.inl(110,103): warning C4458: declaration of 'Extent' hides class member
core\storage_linear.inl(116,103): warning C4458: declaration of 'Extent' hides class member
core\storage_linear.inl(122,103): warning C4458: declaration of 'Extent' hides class member
core\storage_linear.inl(132,22): warning C4458: declaration of 'BlockCount' hides class member
core/image.inl(216,98): warning C4458: declaration of 'BaseLevel' hides class member
gl.hpp(361,28): warning C4458: declaration of 'Profile' hides class member
core/gl.inl(330,39): warning C4458: declaration of 'FormatDesc' hides class member
core/gl.inl(357,61): warning C4458: declaration of 'FormatDesc' hides class member
core/load_ktx.inl(53,58): warning C4100: 'Size': unreferenced formal parameter
core/save_dds.inl(105,61): warning C5054: operator '|': deprecated between enumerations of different types

Additionally fixed unused argument warnings when GLI_ASSERT is disabled (to do this added GLI_UNUSED macro).