### PR TITLE
Warning suppression of deprecated use of non cast enum

### DIFF
--- a/gli/core/save_dds.inl
+++ b/gli/core/save_dds.inl
@@ -102,7 +102,7 @@ namespace detail
 		if(Texture.faces() > 1)
 		{
 			GLI_ASSERT(Texture.faces() == 6);
-			Header.CubemapFlags |= detail::DDSCAPS2_CUBEMAP_ALLFACES | detail::DDSCAPS2_CUBEMAP;
+			Header.CubemapFlags |= static_cast<uint32_t>(detail::DDSCAPS2_CUBEMAP_ALLFACES) | static_cast<uint32_t>(detail::DDSCAPS2_CUBEMAP);
 		}
 
 		// Texture3D


### PR DESCRIPTION
Warning suppression of deprecated use of non cast enum