### PR TITLE
Add braces around initialization of subobject

### DIFF
--- a/test/core/core_flip.cpp
+++ b/test/core/core_flip.cpp
@@ -56,23 +56,23 @@ int main()
 
 	Error += test_texture(
 		gli::texture2d(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8, TextureSize, Levels),
-		gli::detail::dxt1_block{63721, 255, 228, 144, 64, 0},
-		gli::detail::dxt1_block{2516, 215, 152, 173, 215, 106});
+		gli::detail::dxt1_block{63721, 255, {228, 144, 64, 0}},
+		gli::detail::dxt1_block{2516, 215, {152, 173, 215, 106}});
 
 	Error += test_texture(
 		gli::texture2d(gli::FORMAT_RGBA_DXT1_UNORM_BLOCK8, TextureSize, Levels),
-		gli::detail::dxt1_block{63721, 255, 228, 144, 64, 0},
-		gli::detail::dxt1_block{2516, 215, 152, 173, 215, 106});
+		gli::detail::dxt1_block{63721, 255, {228, 144, 64, 0}},
+		gli::detail::dxt1_block{2516, 215, {152, 173, 215, 106}});
 
 	Error += test_texture(
 		gli::texture2d(gli::FORMAT_RGBA_DXT3_UNORM_BLOCK16, TextureSize, Levels),
-		gli::detail::dxt3_block{12514, 1512, 12624, 16614, 63712, 255, 228, 144, 64, 0},
-		gli::detail::dxt3_block{36125, 2416, 46314, 10515, 2516, 215, 152, 173, 215, 106});
+		gli::detail::dxt3_block{{12514, 1512, 12624, 16614}, 63712, 255, {228, 144, 64, 0}},
+		gli::detail::dxt3_block{{36125, 2416, 46314, 10515}, 2516, 215, {152, 173, 215, 106}});
 
 	Error += test_texture(
 		gli::texture2d(gli::FORMAT_RGBA_DXT5_UNORM_BLOCK16, TextureSize, Levels),
-		gli::detail::dxt5_block{255, 0, 64, 30, 50, 45, 242, 68, 63712, 255, 228, 144, 64, 0},
-		gli::detail::dxt5_block{0, 255, 62, 144, 228, 214, 59, 200, 2516, 215, 152, 173, 215, 106});
+		gli::detail::dxt5_block{{255, 0}, {64, 30, 50, 45, 242, 68}, 63712, 255, {228, 144, 64, 0}},
+		gli::detail::dxt5_block{{0, 255}, {62, 144, 228, 214, 59, 200}, 2516, 215, {152, 173, 215, 106}});
 
 	return Error;
 }


### PR DESCRIPTION
This change suppresses a warning about not having braces around the initializers for subobjects:

```
gli/test/core/core_flip.cpp:59:39: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   59 |                 gli::detail::dxt1_block{63721, 255, 228, 144, 64, 0},
      |                                                     ^~~~~~~~~~~~~~~
      |                                                     {              }
gli/test/core/core_flip.cpp:60:38: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   60 |                 gli::detail::dxt1_block{2516, 215, 152, 173, 215, 106});
      |                                                    ^~~~~~~~~~~~~~~~~~
      |                                                    {                 }
gli/test/core/core_flip.cpp:64:39: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   64 |                 gli::detail::dxt1_block{63721, 255, 228, 144, 64, 0},
      |                                                     ^~~~~~~~~~~~~~~
      |                                                     {              }
gli/test/core/core_flip.cpp:65:38: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   65 |                 gli::detail::dxt1_block{2516, 215, 152, 173, 215, 106});
      |                                                    ^~~~~~~~~~~~~~~~~~
      |                                                    {                 }
gli/test/core/core_flip.cpp:69:27: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   69 |                 gli::detail::dxt3_block{12514, 1512, 12624, 16614, 63712, 255, 228, 144, 64, 0},
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                                         {                        }
gli/test/core/core_flip.cpp:69:66: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   69 |                 gli::detail::dxt3_block{12514, 1512, 12624, 16614, 63712, 255, 228, 144, 64, 0},
      |                                                                                ^~~~~~~~~~~~~~~
      |                                                                                {              }
gli/test/core/core_flip.cpp:70:27: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   70 |                 gli::detail::dxt3_block{36125, 2416, 46314, 10515, 2516, 215, 152, 173, 215, 106});
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                                         {                        }
gli/test/core/core_flip.cpp:70:65: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   70 |                 gli::detail::dxt3_block{36125, 2416, 46314, 10515, 2516, 215, 152, 173, 215, 106});
      |                                                                               ^~~~~~~~~~~~~~~~~~
      |                                                                               {                 }
gli/test/core/core_flip.cpp:74:27: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   74 |                 gli::detail::dxt5_block{255, 0, 64, 30, 50, 45, 242, 68, 63712, 255, 228, 144, 64, 0},
      |                                         ^~~~~~
      |                                         {     }
gli/test/core/core_flip.cpp:74:35: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   74 |                 gli::detail::dxt5_block{255, 0, 64, 30, 50, 45, 242, 68, 63712, 255, 228, 144, 64, 0},
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~
      |                                                 {                      }
gli/test/core/core_flip.cpp:74:72: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   74 |                 gli::detail::dxt5_block{255, 0, 64, 30, 50, 45, 242, 68, 63712, 255, 228, 144, 64, 0},
      |                                                                                      ^~~~~~~~~~~~~~~
      |                                                                                      {              }
gli/test/core/core_flip.cpp:75:27: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   75 |                 gli::detail::dxt5_block{0, 255, 62, 144, 228, 214, 59, 200, 2516, 215, 152, 173, 215, 106});
      |                                         ^~~~~~
      |                                         {     }
gli/test/core/core_flip.cpp:75:35: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   75 |                 gli::detail::dxt5_block{0, 255, 62, 144, 228, 214, 59, 200, 2516, 215, 152, 173, 215, 106});
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                 {                         }
gli/test/core/core_flip.cpp:75:74: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   75 |                 gli::detail::dxt5_block{0, 255, 62, 144, 228, 214, 59, 200, 2516, 215, 152, 173, 215, 106});
      |                                                                                        ^~~~~~~~~~~~~~~~~~
      |                                                                                        {                 }
```